### PR TITLE
[Refaktor] Uproszczenie typów szablonowych

### DIFF
--- a/src/Algorithms/Accumulator.hpp
+++ b/src/Algorithms/Accumulator.hpp
@@ -52,7 +52,8 @@ struct AccResults final
 };
 
 template <IsAccumulable DataType>
-class Accumulator final : public BaseClass<DataType, AccResults<DataType>>
+requires std::is_move_constructible_v<DataType>
+class Accumulator final : public BaseClass<AccResults<DataType>>
 {
 public:
     explicit Accumulator(const std::vector<DataType>& data, AccType accType)

--- a/src/Algorithms/Base.hpp
+++ b/src/Algorithms/Base.hpp
@@ -8,7 +8,7 @@
 namespace src::Algorithms
 {
 
-template <typename DataType, typename Container = std::vector<DataType>>
+template <typename Container>
 class BaseClass
 {
 public:

--- a/src/Algorithms/Generator.hpp
+++ b/src/Algorithms/Generator.hpp
@@ -8,7 +8,7 @@ namespace src::Algorithms
 {
 
 template <typename GeneratedDataType, typename StateDataType = GeneratedDataType>
-class Generator final : public BaseClass<GeneratedDataType, std::vector<GeneratedDataType>>
+class Generator final : public BaseClass<std::vector<GeneratedDataType>>
 {
 public:
     explicit Generator(const std::size_t n,

--- a/src/Algorithms/Merger.hpp
+++ b/src/Algorithms/Merger.hpp
@@ -20,7 +20,7 @@ struct MergerData final
 };
 
 template <typename DataType>
-class Merger final : public BaseClass<DataType, std::vector<DataType>>
+class Merger final : public BaseClass<std::vector<DataType>>
 {
 public:
     explicit Merger(const MergerData<DataType>& data)

--- a/src/Algorithms/NthFinder.hpp
+++ b/src/Algorithms/NthFinder.hpp
@@ -23,7 +23,7 @@ struct NthFinderData final
 };
 
 template <typename DataType, NthElementCompatible Container = std::vector<DataType>>
-class NthFinder final : public BaseClass<DataType, Container>
+class NthFinder final : public BaseClass<Container>
 {
 public:
     using Iterator = typename Container::iterator;

--- a/src/Algorithms/Regex.hpp
+++ b/src/Algorithms/Regex.hpp
@@ -19,7 +19,7 @@ struct RegexData final
     const std::string pattern_;
 };
 
-class RegexEvaluator final : public BaseClass<std::string, std::vector<std::string>>
+class RegexEvaluator final : public BaseClass<std::vector<std::string>>
 {
 public:
     explicit RegexEvaluator(const RegexData& data)

--- a/src/Algorithms/Remover.hpp
+++ b/src/Algorithms/Remover.hpp
@@ -25,7 +25,7 @@ struct RemoverData final
 };
 
 template <typename DataType, Removable Container = std::vector<DataType>>
-class Remover final : public BaseClass<DataType, Container>
+class Remover final : public BaseClass<Container>
 {
 public:
     explicit Remover(const RemoverData<DataType, Container>& data)

--- a/src/Algorithms/Sorter.hpp
+++ b/src/Algorithms/Sorter.hpp
@@ -8,7 +8,7 @@ namespace src::Algorithms
 {
 
 template <typename DataType>
-class Sorter final : public BaseClass<DataType, std::vector<DataType>>
+class Sorter final : public BaseClass<std::vector<DataType>>
 {
 public:
     explicit Sorter(const std::vector<DataType>& elements)

--- a/src/Concepts/DataTypeConcepts.hpp
+++ b/src/Concepts/DataTypeConcepts.hpp
@@ -21,11 +21,18 @@ concept Swappable = requires(DataType a, DataType b)
     { std::swap(a, b) } -> std::same_as<void>;
 };
 
-// Koncept sprawdzajacy, czy typ ma operatory ==, <, >
+// Koncept sprawdzajacy, czy typ ma operator ==
 template <typename DataType>
-concept Comparable = requires(DataType a, DataType b)
+concept EqualityComparable = requires(DataType a, DataType b)
 {
     { a == b } -> std::same_as<bool>;
+};
+
+// Koncept sprawdzajacy, czy typ ma operatory ==, <, >
+template <typename DataType>
+concept Comparable = EqualityComparable<DataType> &&
+    requires(DataType a, DataType b)
+{
     { a < b } -> std::same_as<bool>;
     { a > b } -> std::same_as<bool>;
 };

--- a/tests/10Generate/GenerateTestFixture.hpp
+++ b/tests/10Generate/GenerateTestFixture.hpp
@@ -9,20 +9,18 @@ namespace tests::Generate
 {
 
 template <typename GeneratedDataType, typename StateDataType = GeneratedDataType>
-struct GenerateTestStruct : public BaseTestStruct<Generator<GeneratedDataType, StateDataType>>
+struct GenerateTestStruct : public BaseTestStruct<std::vector<GeneratedDataType>>
 {
 protected:
     explicit GenerateTestStruct(const TestType testType,
         std::shared_ptr<Generator<GeneratedDataType, StateDataType>>&& f)
-    : BaseTestStruct<Generator<GeneratedDataType, StateDataType>>(testType, std::move(f))
+    : BaseTestStruct<std::vector<GeneratedDataType>>(testType, std::move(f))
     { }
 };
 
 // Klasa abstrakcyjna GenerateTestFixture, po ktorej dziedzicza klasy testowe metod generate
 template <typename GeneratedDataType, typename StateDataType = GeneratedDataType> 
-class GenerateTestFixture : public BaseTestFixture<
-    std::vector<GeneratedDataType>,
-    Generator<GeneratedDataType, StateDataType>>
+class GenerateTestFixture : public BaseTestFixture<std::vector<GeneratedDataType>>
 {
 protected:
     GenerateTestFixture() = default;

--- a/tests/10Generate/RandomString2/RandomStringTests.hpp
+++ b/tests/10Generate/RandomString2/RandomStringTests.hpp
@@ -21,7 +21,7 @@ class RandomStringGenerateFixture : public GenerateTestFixture<std::string, Rand
 {
 public:
     void VerifyTestCustomForRandomStringGenerator(
-        const BaseTestStruct<Generator<std::string, RandomString>>& args)
+        const BaseTestStruct<std::vector<std::string>>& args)
     {
         using namespace std::placeholders;
         auto checker = std::bind(&RandomStringGenerateFixture::verifyRandomStringGenerator, this, _1, _2, _3, _4);

--- a/tests/2Accumulate/AccumulateTestFixture.hpp
+++ b/tests/2Accumulate/AccumulateTestFixture.hpp
@@ -8,23 +8,23 @@ using namespace src::Algorithms;
 namespace tests::Accumulate
 {
 template <typename DataType>
-struct AccumulateTestStruct : public BaseTestStruct<Accumulator<DataType>>
+struct AccumulateTestStruct : public BaseTestStruct<AccResults<DataType>>
 {
 protected:
     explicit AccumulateTestStruct(const TestType testType,
         std::shared_ptr<Accumulator<DataType>>&& f)
-    : BaseTestStruct<Accumulator<DataType>>(testType, std::move(f))
+    : BaseTestStruct<AccResults<DataType>>(testType, std::move(f))
     { }
 };
 
 // Klasa abstrakcyjna AccumulateTestFixture, po ktorej dziedzicza klasy testowe metod Accumulate
 template <typename DataType>
-class AccumulateTestFixture : public BaseTestFixture<AccResults<DataType>, Accumulator<DataType>>
+class AccumulateTestFixture : public BaseTestFixture<AccResults<DataType>>
 {
 protected:
     AccumulateTestFixture() = default;
 
-    void VerifyTestCustomFor2(const BaseTestStruct<Accumulator<DataType>>& args)
+    void VerifyTestCustomFor2(const BaseTestStruct<AccResults<DataType>>& args)
     {
         using namespace std::placeholders;
         auto checker = std::bind(&AccumulateTestFixture::verifyCustomFor2, this, _1, _2, _3, _4);
@@ -37,6 +37,7 @@ private:
         const AccResults<DataType>& boostResult,
         const AccResults<DataType>& simpleResult,
         std::ostringstream& os)
+    requires EqualityComparable<DataType>
     {
         EXPECT_EQ_OS(stlResult.sum, boostResult.sum, os) << "Sumy STL i Boost roznia sie";
         EXPECT_EQ_OS(stlResult.sum, simpleResult.sum, os) << "Sumy STL i Simple roznia sie";

--- a/tests/3Merge/MergeTestFixture.hpp
+++ b/tests/3Merge/MergeTestFixture.hpp
@@ -9,12 +9,12 @@ namespace tests::Merge
 {
 
 template <typename DataType>
-struct MergeTestStruct : public BaseTestStruct<Merger<DataType>>
+struct MergeTestStruct : public BaseTestStruct<std::vector<DataType>>
 {
 protected:
     explicit MergeTestStruct(const TestType testType,
         std::shared_ptr<Merger<DataType>>&& f)
-    : BaseTestStruct<Merger<DataType>>(testType, std::move(f))
+    : BaseTestStruct<std::vector<DataType>>(testType, std::move(f))
     { }
 
     static MergerData<DataType> initTestData(
@@ -42,7 +42,7 @@ protected:
 
 // Klasa abstrakcyjna MergeTestFixture, po ktorej dziedzicza klasy testowe metod merge
 template <typename DataType>
-class MergeTestFixture : public BaseTestFixture<std::vector<DataType>, Merger<DataType>>
+class MergeTestFixture : public BaseTestFixture<std::vector<DataType>>
 {
 protected:
     MergeTestFixture() = default;

--- a/tests/5Sort/SortTestFixture.hpp
+++ b/tests/5Sort/SortTestFixture.hpp
@@ -11,18 +11,18 @@ namespace tests::Sort
 {
 
 template <typename DataType>
-struct SortTestStruct : public BaseTestStruct<Sorter<DataType>>
+struct SortTestStruct : public BaseTestStruct<std::vector<DataType>>
 {
 protected:
     explicit SortTestStruct(const TestType testType,
         std::shared_ptr<Sorter<DataType>>&& f)
-    : BaseTestStruct<Sorter<DataType>>(testType, std::move(f))
+    : BaseTestStruct<std::vector<DataType>>(testType, std::move(f))
     { }
 };
 
 // Klasa abstrakcyjna SortTestFixture, po ktorej dziedzicza klasy testowe metod sort
 template <typename DataType>
-class SortTestFixture : public BaseTestFixture<std::vector<DataType>, Sorter<DataType>>
+class SortTestFixture : public BaseTestFixture<std::vector<DataType>>
 {
 protected:
     SortTestFixture() = default;

--- a/tests/7NthElement/NthElementTestFixture.hpp
+++ b/tests/7NthElement/NthElementTestFixture.hpp
@@ -10,13 +10,13 @@ namespace tests::NthElement
 {
 
 template <typename DataType, NthElementCompatible Container = std::vector<DataType>>
-struct NthElementTestStruct : public BaseTestStruct<NthFinder<DataType, Container>>
+struct NthElementTestStruct : public BaseTestStruct<Container>
 {
 protected:
     explicit NthElementTestStruct(
         const TestType testType,
         std::shared_ptr<NthFinder<DataType, Container>>&& f)
-    : BaseTestStruct<NthFinder<DataType, Container>>(testType, std::move(f))
+    : BaseTestStruct<Container>(testType, std::move(f))
     { }
 
     static NthFinderData<DataType, Container> initTestData(
@@ -40,13 +40,13 @@ protected:
 
 // Klasa abstrakcyjna NthElementTestFixture, po ktorej dziedzicza klasy testowe metod NthElement
 template <typename DataType, NthElementCompatible Container = std::vector<DataType>>
-class NthElementTestFixture : public BaseTestFixture<Container, NthFinder<DataType, Container>>
+class NthElementTestFixture : public BaseTestFixture<Container>
 {
 protected:
-    void VerifyTestCustomFor7(const BaseTestStruct<NthFinder<DataType, Container>>& args)
+    void VerifyTestCustomFor7(const BaseTestStruct<Container>& args)
     {
         using namespace std::placeholders;
-        const std::size_t n = args.get(&NthFinder<DataType, Container>::n_);
+        const std::size_t n = args.getField(&NthFinder<DataType, Container>::n_);
         auto checker = std::bind(&NthElementTestFixture::verifyCustomFor7, this, _1, _2, _3, _4, n);
         this->VerifyTest(args, checker);
     }
@@ -58,6 +58,7 @@ private:
         const Container& simpleResult,
         std::ostringstream& os,
         const unsigned int n)
+    requires EqualityComparable<DataType>
     {
         // Petla for do porownywania wynikow, jesli rozmiary sa rowne
         auto stlIter = stlResult.begin();

--- a/tests/8Regex/RegexTests.hpp
+++ b/tests/8Regex/RegexTests.hpp
@@ -15,11 +15,11 @@ enum class ERegexTestType : unsigned char
     date
 };
 
-struct RegexTestStruct final : public BaseTestStruct<RegexEvaluator>
+struct RegexTestStruct final : public BaseTestStruct<std::vector<std::string>>
 {
 public:
     explicit RegexTestStruct(const unsigned int textLength, const ERegexTestType testType)
-    : BaseTestStruct<RegexEvaluator>(TestType::RegexType, createEvaluatorPtr(textLength, testType))
+    : BaseTestStruct<std::vector<std::string>>(TestType::RegexType, createEvaluatorPtr(textLength, testType))
     { }
 
 private:
@@ -52,7 +52,7 @@ private:
     }
 };
 
-class RegexTestFixture : public BaseTestFixture<std::vector<std::string>, RegexEvaluator>
+class RegexTestFixture : public BaseTestFixture<std::vector<std::string>>
 {
 };
 

--- a/tests/9RemoveEraseIf/RemoveEraseIfTestFixture.hpp
+++ b/tests/9RemoveEraseIf/RemoveEraseIfTestFixture.hpp
@@ -10,12 +10,12 @@ namespace tests::RemoveEraseIf
 {
 
 template <typename DataType, Removable Container = std::vector<DataType>>
-struct RemoveEraseIfTestStruct : public BaseTestStruct<Remover<DataType, Container>>
+struct RemoveEraseIfTestStruct : public BaseTestStruct<Container>
 {
 protected:
     explicit RemoveEraseIfTestStruct(const TestType testType,
         std::shared_ptr<Remover<DataType, Container>>&& f)
-    : BaseTestStruct<Remover<DataType, Container>>(testType, std::move(f))
+    : BaseTestStruct<Container>(testType, std::move(f))
     { }
 
     static RemoverData<DataType, Container> initTestData(
@@ -37,7 +37,7 @@ protected:
 
 // Klasa abstrakcyjna RemoveEraseIfTestFixture, po ktorej dziedzicza klasy testowe metod RemoveEraseIf
 template <typename DataType, Removable Container = std::vector<DataType>>
-class RemoveEraseIfTestFixture : public BaseTestFixture<Container, Remover<DataType, Container>>
+class RemoveEraseIfTestFixture : public BaseTestFixture<Container>
 {
 protected:
     RemoveEraseIfTestFixture() = default;


### PR DESCRIPTION
Od teraz nie ma typu szablonowego PtrType oraz klasy bazowe mają mniej argumentów szablonowych. Zwalidowałem też getField w BaseTestStruct aby nie dochodziło do złego użycia.