### PR TITLE
[Poprawka] Przyspieszenie działania testów

### DIFF
--- a/src/Algorithms/Accumulator.hpp
+++ b/src/Algorithms/Accumulator.hpp
@@ -65,18 +65,18 @@ public:
 private:
     void resetData() const override { }
 
-    void FOR_ITER(const std::function<void(DataType)>& f) const
+    void FOR_ITER(const std::function<void(DataType)>& dataCallback) const
     {
         for (auto it = data_.begin(); it != data_.end(); ++it)
         {
-            f(*it);
+            dataCallback(*it);
         }
     }
 
     template <typename AccumulatorSet>
     void FOR_ITER_ON_ACC(AccumulatorSet& acc) const
     {
-        FOR_ITER([&acc](const DataType& wrapper) { acc(wrapper); });
+        FOR_ITER([&acc](const DataType& value) { acc(value); });
     }
 
     AccResults<DataType> executeSTL() const override
@@ -152,19 +152,19 @@ private:
 
         if (accType_ == AccType::SumOnly || accType_ == AccType::SumAndMean)
         {
-            FOR_ITER([&results](const DataType& wrapper) { results.sum += wrapper; });
+            FOR_ITER([&results](const DataType& value) { results.sum += value; });
         }
         else // AccType::SumAndExtremes, AccType::DoItAll
         {
             results.minimum = *data_.begin();
             results.maximum = *data_.begin();
-            FOR_ITER([&results](const DataType& wrapper)
+            FOR_ITER([&results](const DataType& value)
             {
-                results.sum += wrapper;
-                if (wrapper < results.minimum)
-                    results.minimum = wrapper;
-                else if (wrapper > results.maximum)
-                    results.maximum = wrapper;
+                results.sum += value;
+                if (value < results.minimum)
+                    results.minimum = value;
+                else if (value > results.maximum)
+                    results.maximum = value;
             });
         }
 

--- a/src/Algorithms/Base.hpp
+++ b/src/Algorithms/Base.hpp
@@ -26,8 +26,23 @@ public:
         }
     }
 
+    std::tuple<Container, Container, Container> callEach() const
+    {
+        const Container& stlResult = executeSTL();
+        const Container& boostResult = executeBoost();
+        const Container& simpleResult = executeSimple();
+        return { stlResult, boostResult, simpleResult };
+    }
+
 protected:
     BaseClass() = default;
+
+    // tylko przenoszenie
+    BaseClass(BaseClass&&) = default;
+    BaseClass& operator=(BaseClass&&) = default;
+    BaseClass(const BaseClass&) = delete;
+    BaseClass& operator=(const BaseClass&) = delete;
+
     virtual ~BaseClass() = default;
     virtual void resetData() const = 0;
     virtual Container executeSTL() const = 0;

--- a/src/Algorithms/Generator.hpp
+++ b/src/Algorithms/Generator.hpp
@@ -57,8 +57,8 @@ private:
         return sequence;
     }
 
-    const std::size_t n_;
-    const StateDataType initialState_;
+    std::size_t n_;
+    StateDataType initialState_;
     mutable StateDataType currentState_;
     std::function<GeneratedDataType(StateDataType&)> generator_;
 };

--- a/src/Structures/RandomStringImpl.hpp
+++ b/src/Structures/RandomStringImpl.hpp
@@ -33,8 +33,8 @@ public:
     static std::shared_ptr<StrGenerator> 
     createGenerator(const unsigned int vectorSize, const unsigned int length)
     {
-        const StrGenerator& generator = createGeneratorData(vectorSize, length);
-        return std::make_shared<StrGenerator>(generator);
+        StrGenerator generator = createGeneratorData(vectorSize, length);
+        return std::make_shared<StrGenerator>(std::move(generator));
     }
 
     static std::shared_ptr<NthFinder<std::vector<std::string>>> createFinder(
@@ -50,8 +50,8 @@ public:
             elements.emplace_back(generator.create());
         }
 
-        NthFinderData<std::vector<std::string>> data(elements, n);
-        return std::make_shared<NthFinder<std::vector<std::string>>>(data);
+        NthFinderData<std::vector<std::string>> data(std::move(elements), n);
+        return std::make_shared<NthFinder<std::vector<std::string>>>(std::move(data));
     }
 };
 

--- a/tests/10Generate/Fibonacci1/FibonacciTests.cpp
+++ b/tests/10Generate/Fibonacci1/FibonacciTests.cpp
@@ -4,19 +4,19 @@ namespace tests::Generate
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    FibonacciGenerateIntPrefix,
+    GeneratePrefix,
     FibonacciGenerateIntFixture,
     ::testing::Values(
-        FibonacciGenerateArgs<int>(std::make_pair(1, 1), 45u),
-        FibonacciGenerateArgs<int>(std::make_pair(2, 2), 40u)
+        std::make_shared<FibonacciGenerateArgs<int>>(std::make_pair(1, 1), 45u),
+        std::make_shared<FibonacciGenerateArgs<int>>(std::make_pair(2, 2), 40u)
     ));
 
 INSTANTIATE_TEST_SUITE_P(
-    FibonacciGenerateDoublePrefix, 
+    GeneratePrefix, 
     FibonacciGenerateDoubleFixture,
     ::testing::Values(
-        FibonacciGenerateArgs<double>(std::make_pair(1.0, 1.0), 80u),
-        FibonacciGenerateArgs<double>(std::make_pair(1.5, 2.5), 60u)
+        std::make_shared<FibonacciGenerateArgs<double>>(std::make_pair(1.0, 1.0), 80u),
+        std::make_shared<FibonacciGenerateArgs<double>>(std::make_pair(1.5, 2.5), 60u)
     ));
 
 } // namespace tests::Generate

--- a/tests/10Generate/Fibonacci1/FibonacciTests.hpp
+++ b/tests/10Generate/Fibonacci1/FibonacciTests.hpp
@@ -16,12 +16,17 @@ struct FibonacciGenerateArgs final : public GenerateTestStruct<DataType, std::pa
         unsigned int n)
     : GenerateTestStruct<DataType, std::pair<DataType, DataType>>(
         TestType::GenerateFibonacci,
-        std::make_shared<Generator<DataType, std::pair<DataType, DataType>>>(n, initialPair,
-            [](std::pair<DataType, DataType>& currentState)
+        [initialPair, n]()
+        {
+            auto stateCreator = [](std::pair<DataType, DataType>& currentState)
             {
                 currentState = std::make_pair(currentState.second, currentState.first + currentState.second);
                 return currentState.first;
-            }))
+            };
+
+            return std::make_shared<Generator<DataType, std::pair<DataType, DataType>>>(
+                n, initialPair, stateCreator);
+        })
     { }
 };
 

--- a/tests/10Generate/GenerateTestFixture.hpp
+++ b/tests/10Generate/GenerateTestFixture.hpp
@@ -13,8 +13,8 @@ struct GenerateTestStruct : public BaseTestStruct<std::vector<GeneratedDataType>
 {
 protected:
     explicit GenerateTestStruct(const TestType testType,
-        std::shared_ptr<Generator<GeneratedDataType, StateDataType>>&& f)
-    : BaseTestStruct<std::vector<GeneratedDataType>>(testType, std::move(f))
+        Callback<Generator<GeneratedDataType, StateDataType>>&& callback)
+    : BaseTestStruct<std::vector<GeneratedDataType>>(testType, std::move(callback))
     { }
 };
 

--- a/tests/10Generate/Matrix3/MatrixTests.cpp
+++ b/tests/10Generate/Matrix3/MatrixTests.cpp
@@ -5,21 +5,21 @@ namespace tests::Generate
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    MatrixGenerateIntPrefix, 
+    GeneratePrefix, 
     MatrixGenerateIntFixture,
     ::testing::Values(
-        MatrixGenerateArgs<int>(Examples::a1(), 10000u),
-        MatrixGenerateArgs<int>(Examples::c1(50u), 100u),
-        MatrixGenerateArgs<int>(Examples::c1(100u), 50u)
+        std::make_shared<MatrixGenerateArgs<int>>(Examples::a1(), 10000u),
+        std::make_shared<MatrixGenerateArgs<int>>(Examples::c1(50u), 100u),
+        std::make_shared<MatrixGenerateArgs<int>>(Examples::c1(100u), 50u)
     ));
 
 INSTANTIATE_TEST_SUITE_P(
-    MatrixGenerateDoublePrefix,
+    GeneratePrefix,
     MatrixGenerateDoubleFixture,
     ::testing::Values(
-        MatrixGenerateArgs<double>(Examples::b1(10u), 500u),
-        MatrixGenerateArgs<double>(Examples::b1(75u), 200u),
-        MatrixGenerateArgs<double>(Examples::b1(150u), 100u)
+        std::make_shared<MatrixGenerateArgs<double>>(Examples::b1(10u), 500u),
+        std::make_shared<MatrixGenerateArgs<double>>(Examples::b1(75u), 200u),
+        std::make_shared<MatrixGenerateArgs<double>>(Examples::b1(150u), 100u)
     ));
 
 } // namespace tests::Generate

--- a/tests/10Generate/Matrix3/MatrixTests.hpp
+++ b/tests/10Generate/Matrix3/MatrixTests.hpp
@@ -16,13 +16,17 @@ struct MatrixGenerateArgs final : public GenerateTestStruct<Matrix<Number>>
         const Matrix<Number>& initialMatrix,
         const unsigned int n)
     : GenerateTestStruct<Matrix<Number>>(
-    TestType::GenerateMatrix,
-    std::make_shared<Generator<Matrix<Number>>>(n, initialMatrix,
-        [initialState = initialMatrix](Matrix<Number>& currentState)
+        TestType::GenerateMatrix,
+        [initialMatrix, n]()
         {
-            currentState *= initialState;
-            return currentState;
-        }))
+            auto stateCreator = [initialMatrix](Matrix<Number>& currentState)
+            {
+                currentState *= initialMatrix;
+                return currentState;
+            };
+
+            return std::make_shared<Generator<Matrix<Number>>>(n, initialMatrix, stateCreator);
+        })
     { }
 };
 

--- a/tests/10Generate/RandomString2/RandomStringTests.cpp
+++ b/tests/10Generate/RandomString2/RandomStringTests.cpp
@@ -4,16 +4,16 @@ namespace tests::Generate
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    RandomStringGeneratePrefix,
+    GeneratePrefix,
     RandomStringGenerateFixture,
     ::testing::Values( // dlugosc slowa, ilosc slow
-        RandomStringGenerateArgs(1u, 1000000u),
-        RandomStringGenerateArgs(20u, 50000u),
-        RandomStringGenerateArgs(200u, 5000u),
-        RandomStringGenerateArgs(1000u, 1000u),
-        RandomStringGenerateArgs(5000u, 200u),
-        RandomStringGenerateArgs(50000u, 20u),
-        RandomStringGenerateArgs(1000000u, 1u)
+        std::make_shared<RandomStringGenerateArgs>(1u, 1000000u),
+        std::make_shared<RandomStringGenerateArgs>(20u, 50000u),
+        std::make_shared<RandomStringGenerateArgs>(200u, 5000u),
+        std::make_shared<RandomStringGenerateArgs>(1000u, 1000u),
+        std::make_shared<RandomStringGenerateArgs>(5000u, 200u),
+        std::make_shared<RandomStringGenerateArgs>(50000u, 20u),
+        std::make_shared<RandomStringGenerateArgs>(1000000u, 1u)
 ));
 
 } // namespace tests::Generate

--- a/tests/10Generate/RandomString2/RandomStringTests.hpp
+++ b/tests/10Generate/RandomString2/RandomStringTests.hpp
@@ -13,7 +13,10 @@ struct RandomStringGenerateArgs final : public GenerateTestStruct<std::string, R
     explicit RandomStringGenerateArgs(const unsigned int l, const unsigned int n)
     : GenerateTestStruct<std::string, RandomString>(
         TestType::GenerateRandomString,
-        RandomStringImpl::createGenerator(n, l))
+        [n, l]()
+        {
+            return RandomStringImpl::createGenerator(n, l);
+        })
     { }
 };
 
@@ -21,7 +24,7 @@ class RandomStringGenerateFixture : public GenerateTestFixture<std::string, Rand
 {
 public:
     void VerifyTestCustomForRandomStringGenerator(
-        const BaseTestStruct<std::vector<std::string>>& args)
+        const std::shared_ptr<BaseTestStruct<std::vector<std::string>>>& args)
     {
         using namespace std::placeholders;
         auto checker = std::bind(&RandomStringGenerateFixture::verifyRandomStringGenerator, this, _1, _2, _3, _4);

--- a/tests/1MinMax/BasicSet3/UIntTests.cpp
+++ b/tests/1MinMax/BasicSet3/UIntTests.cpp
@@ -8,23 +8,24 @@ namespace tests::MinMax
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    BasicSetMinMaxPrefix,
+    MinMaxPrefix,
     BasicSetMinMaxFixture,
     ::testing::Values(
         // generator rosnacych liczb
-        BasicSetMinMaxArgs(BasicSetMinMaxFixture::sortedGenerator,
-                   SMALL_TEST),
-        BasicSetMinMaxArgs(BasicSetMinMaxFixture::sortedGenerator,
-                   MEDIUM_TEST),
-        BasicSetMinMaxArgs(BasicSetMinMaxFixture::sortedGenerator,
-                   BIG_TEST),
+        std::make_shared<BasicSetMinMaxArgs>(
+            BasicSetMinMaxFixture::sortedGenerator, SMALL_TEST),
+        std::make_shared<BasicSetMinMaxArgs>(
+            BasicSetMinMaxFixture::sortedGenerator, MEDIUM_TEST),
+        std::make_shared<BasicSetMinMaxArgs>(
+            BasicSetMinMaxFixture::sortedGenerator, BIG_TEST),
+
         // generator malejacych liczb
-        BasicSetMinMaxArgs(BasicSetMinMaxFixture::reverseSortedGenerator,
-                   SMALL_TEST),
-        BasicSetMinMaxArgs(BasicSetMinMaxFixture::reverseSortedGenerator,
-                   MEDIUM_TEST),
-        BasicSetMinMaxArgs(BasicSetMinMaxFixture::reverseSortedGenerator,
-                   BIG_TEST)
+        std::make_shared<BasicSetMinMaxArgs>(
+            BasicSetMinMaxFixture::reverseSortedGenerator, SMALL_TEST),
+        std::make_shared<BasicSetMinMaxArgs>(
+            BasicSetMinMaxFixture::reverseSortedGenerator, MEDIUM_TEST),
+        std::make_shared<BasicSetMinMaxArgs>(
+            BasicSetMinMaxFixture::reverseSortedGenerator, BIG_TEST)
     ));
 
 } // namespace tests::MinMax

--- a/tests/1MinMax/BasicSet3/UIntTests.hpp
+++ b/tests/1MinMax/BasicSet3/UIntTests.hpp
@@ -8,12 +8,16 @@ namespace tests::MinMax
 struct BasicSetMinMaxArgs final : public MinMaxTestStruct<std::set<unsigned int>>
 {
     explicit BasicSetMinMaxArgs(
-        unsigned int (*f)(const unsigned int),
+        unsigned int (*dataCreator)(const unsigned int),
         const unsigned int n)
     : MinMaxTestStruct<std::set<unsigned int>>(
         TestType::MinMaxBasicSet,
-        std::make_shared<MinMaxFinder<std::set<unsigned int>>>(
-            initTestData<std::set<unsigned int>>(f, n)))
+        [dataCreator, n]()
+        {
+            std::set<unsigned int> data =
+                BaseTestStruct::initTestData<std::set<unsigned int>>(dataCreator, n);
+            return std::make_shared<MinMaxFinder<std::set<unsigned int>>>(std::move(data));
+        })
     { }
 };
 

--- a/tests/1MinMax/BasicVector1/UIntTests.cpp
+++ b/tests/1MinMax/BasicVector1/UIntTests.cpp
@@ -8,23 +8,24 @@ namespace tests::MinMax
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    BasicVectorMinMaxPrefix,
+    MinMaxPrefix,
     BasicVectorMinMaxFixture,
     ::testing::Values(
         // generator rosnacych liczb
-        BasicVectorMinMaxArgs(BasicVectorMinMaxFixture::sortedGenerator,
-                   SMALL_TEST),
-        BasicVectorMinMaxArgs(BasicVectorMinMaxFixture::sortedGenerator,
-                   MEDIUM_TEST),
-        BasicVectorMinMaxArgs(BasicVectorMinMaxFixture::sortedGenerator,
-                   BIG_TEST),
+        std::make_shared<BasicVectorMinMaxArgs>(
+            BasicVectorMinMaxFixture::sortedGenerator, SMALL_TEST),
+        std::make_shared<BasicVectorMinMaxArgs>(
+            BasicVectorMinMaxFixture::sortedGenerator, MEDIUM_TEST),
+        std::make_shared<BasicVectorMinMaxArgs>(
+            BasicVectorMinMaxFixture::sortedGenerator, BIG_TEST),
+
         // generator malejacych liczb
-        BasicVectorMinMaxArgs(BasicVectorMinMaxFixture::reverseSortedGenerator,
-                   SMALL_TEST),
-        BasicVectorMinMaxArgs(BasicVectorMinMaxFixture::reverseSortedGenerator,
-                   MEDIUM_TEST),
-        BasicVectorMinMaxArgs(BasicVectorMinMaxFixture::reverseSortedGenerator,
-                   BIG_TEST)
+        std::make_shared<BasicVectorMinMaxArgs>(
+            BasicVectorMinMaxFixture::reverseSortedGenerator, SMALL_TEST),
+        std::make_shared<BasicVectorMinMaxArgs>(
+            BasicVectorMinMaxFixture::reverseSortedGenerator, MEDIUM_TEST),
+        std::make_shared<BasicVectorMinMaxArgs>(
+            BasicVectorMinMaxFixture::reverseSortedGenerator, BIG_TEST)
     ));
 
 } // namespace tests::MinMax

--- a/tests/1MinMax/BasicVector1/UIntTests.hpp
+++ b/tests/1MinMax/BasicVector1/UIntTests.hpp
@@ -8,12 +8,16 @@ namespace tests::MinMax
 struct BasicVectorMinMaxArgs final : public MinMaxTestStruct<std::vector<unsigned int>>
 {
     explicit BasicVectorMinMaxArgs(
-        unsigned int (*f)(const unsigned int),
+        unsigned int (*dataCreator)(const unsigned int),
         const unsigned int n)
     : MinMaxTestStruct<std::vector<unsigned int>>(
         TestType::MinMaxBasicVector,
-        std::make_shared<MinMaxFinder<std::vector<unsigned int>>>(
-            initTestData<std::vector<unsigned int>>(f, n)))
+        [dataCreator, n]()
+        {
+            std::vector<unsigned int> data =
+                BaseTestStruct::initTestData<std::vector<unsigned int>>(dataCreator, n);
+            return std::make_shared<MinMaxFinder<std::vector<unsigned int>>>(std::move(data));
+        })
     { }
 };
 

--- a/tests/1MinMax/MinMaxTestFixture.hpp
+++ b/tests/1MinMax/MinMaxTestFixture.hpp
@@ -14,8 +14,8 @@ struct MinMaxTestStruct : public BaseTestStruct<Container>
 {
 protected:
     explicit MinMaxTestStruct(const TestType testType,
-        std::shared_ptr<MinMaxFinder<Container>>&& f)
-    : BaseTestStruct<Container>(testType, std::move(f))
+        Callback<MinMaxFinder<Container>>&& callback)
+    : BaseTestStruct<Container>(testType, std::move(callback))
     { }
 };
 

--- a/tests/1MinMax/VectorOfVectors2/IntVectorTests.cpp
+++ b/tests/1MinMax/VectorOfVectors2/IntVectorTests.cpp
@@ -8,23 +8,24 @@ namespace tests::MinMax
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    VectorOfVectorsMinMaxPrefix,
+    MinMaxPrefix,
     VectorOfVectorsMinMaxFixture,
     ::testing::Values(
         // generator rosnacych liczb
-        VectorOfVectorsMinMaxArgs(VectorOfVectorsMinMaxFixture::sortedLastElementGenerator,
-                   SMALL_TEST),
-        VectorOfVectorsMinMaxArgs(VectorOfVectorsMinMaxFixture::sortedLastElementGenerator,
-                   MEDIUM_TEST),
-        VectorOfVectorsMinMaxArgs(VectorOfVectorsMinMaxFixture::sortedLastElementGenerator,
-                   BIG_TEST),
+        std::make_shared<VectorOfVectorsMinMaxArgs>(
+            VectorOfVectorsMinMaxFixture::sortedLastElementGenerator, SMALL_TEST),
+        std::make_shared<VectorOfVectorsMinMaxArgs>(
+            VectorOfVectorsMinMaxFixture::sortedLastElementGenerator, MEDIUM_TEST),
+        std::make_shared<VectorOfVectorsMinMaxArgs>(
+            VectorOfVectorsMinMaxFixture::sortedLastElementGenerator, BIG_TEST),
+
         // generator malejacych liczb
-        VectorOfVectorsMinMaxArgs(VectorOfVectorsMinMaxFixture::randomGenerator,
-                   SMALL_TEST),
-        VectorOfVectorsMinMaxArgs(VectorOfVectorsMinMaxFixture::randomGenerator,
-                   MEDIUM_TEST),
-        VectorOfVectorsMinMaxArgs(VectorOfVectorsMinMaxFixture::randomGenerator,
-                   BIG_TEST)
+        std::make_shared<VectorOfVectorsMinMaxArgs>(
+            VectorOfVectorsMinMaxFixture::randomGenerator, SMALL_TEST),
+        std::make_shared<VectorOfVectorsMinMaxArgs>(
+            VectorOfVectorsMinMaxFixture::randomGenerator, MEDIUM_TEST),
+        std::make_shared<VectorOfVectorsMinMaxArgs>(
+            VectorOfVectorsMinMaxFixture::randomGenerator, BIG_TEST)
     ));
 
 } // namespace tests::MinMax

--- a/tests/1MinMax/VectorOfVectors2/IntVectorTests.hpp
+++ b/tests/1MinMax/VectorOfVectors2/IntVectorTests.hpp
@@ -11,12 +11,16 @@ namespace tests::MinMax
 struct VectorOfVectorsMinMaxArgs final : public MinMaxTestStruct<std::vector<IntVector>>
 {
     explicit VectorOfVectorsMinMaxArgs(
-        IntVector (*f)(const unsigned int),
+        IntVector (*dataCreator)(const unsigned int),
         const unsigned int n)
     : MinMaxTestStruct<std::vector<IntVector>>(
         TestType::MinMaxVectorOfVectors,
-        std::make_shared<MinMaxFinder<std::vector<IntVector>>>(
-            initTestData<std::vector<IntVector>>(f, n)))
+        [dataCreator, n]()
+        {
+            std::vector<IntVector> data =
+                BaseTestStruct::initTestData<std::vector<IntVector>>(dataCreator, n);
+            return std::make_shared<MinMaxFinder<std::vector<IntVector>>>(std::move(data));
+        })
     { }
 };
 

--- a/tests/1MinMax/VectorSet4/IntVectorTests.cpp
+++ b/tests/1MinMax/VectorSet4/IntVectorTests.cpp
@@ -8,23 +8,24 @@ namespace tests::MinMax
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    VectorSetMinMaxPrefix,
+    MinMaxPrefix,
     VectorSetMinMaxFixture,
     ::testing::Values(
         // generator rosnacych liczb
-        VectorSetMinMaxArgs(VectorSetMinMaxFixture::sortedLastElementGenerator,
-                   SMALL_TEST),
-        VectorSetMinMaxArgs(VectorSetMinMaxFixture::sortedLastElementGenerator,
-                   MEDIUM_TEST),
-        VectorSetMinMaxArgs(VectorSetMinMaxFixture::sortedLastElementGenerator,
-                   BIG_TEST),
+        std::make_shared<VectorSetMinMaxArgs>(
+            VectorSetMinMaxFixture::sortedLastElementGenerator, SMALL_TEST),
+        std::make_shared<VectorSetMinMaxArgs>(
+            VectorSetMinMaxFixture::sortedLastElementGenerator, MEDIUM_TEST),
+        std::make_shared<VectorSetMinMaxArgs>(
+            VectorSetMinMaxFixture::sortedLastElementGenerator, BIG_TEST),
+
         // generator malejacych liczb
-        VectorSetMinMaxArgs(VectorSetMinMaxFixture::randomGenerator,
-                   SMALL_TEST),
-        VectorSetMinMaxArgs(VectorSetMinMaxFixture::randomGenerator,
-                   MEDIUM_TEST),
-        VectorSetMinMaxArgs(VectorSetMinMaxFixture::randomGenerator,
-                   BIG_TEST)
+        std::make_shared<VectorSetMinMaxArgs>(
+            VectorSetMinMaxFixture::randomGenerator, SMALL_TEST),
+        std::make_shared<VectorSetMinMaxArgs>(
+            VectorSetMinMaxFixture::randomGenerator, MEDIUM_TEST),
+        std::make_shared<VectorSetMinMaxArgs>(
+            VectorSetMinMaxFixture::randomGenerator, BIG_TEST)
     ));
 
 } // namespace tests::MinMax

--- a/tests/1MinMax/VectorSet4/IntVectorTests.hpp
+++ b/tests/1MinMax/VectorSet4/IntVectorTests.hpp
@@ -11,12 +11,16 @@ namespace tests::MinMax
 struct VectorSetMinMaxArgs final : public MinMaxTestStruct<std::set<IntVector>>
 {
     explicit VectorSetMinMaxArgs(
-        IntVector (*f)(const unsigned int),
+        IntVector (*dataCreator)(const unsigned int),
         const unsigned int n)
     : MinMaxTestStruct<std::set<IntVector>>(
         TestType::MinMaxVectorSet,
-        std::make_shared<MinMaxFinder<std::set<IntVector>>>(
-            initTestData<std::set<IntVector>>(f, n)))
+        [dataCreator, n]()
+        {
+            std::set<IntVector> data =
+                BaseTestStruct::initTestData<std::set<IntVector>>(dataCreator, n);
+            return std::make_shared<MinMaxFinder<std::set<IntVector>>>(std::move(data));
+        })
     { }
 };
 

--- a/tests/2Accumulate/AccumulateTestFixture.hpp
+++ b/tests/2Accumulate/AccumulateTestFixture.hpp
@@ -12,8 +12,8 @@ struct AccumulateTestStruct : public BaseTestStruct<AccResults<DataType>>
 {
 protected:
     explicit AccumulateTestStruct(const TestType testType,
-        std::shared_ptr<Accumulator<DataType>>&& f)
-    : BaseTestStruct<AccResults<DataType>>(testType, std::move(f))
+        Callback<Accumulator<DataType>>&& callback)
+    : BaseTestStruct<AccResults<DataType>>(testType, std::move(callback))
     { }
 };
 
@@ -24,7 +24,7 @@ class AccumulateTestFixture : public BaseTestFixture<AccResults<DataType>>
 protected:
     AccumulateTestFixture() = default;
 
-    void VerifyTestCustomFor2(const BaseTestStruct<AccResults<DataType>>& args)
+    void VerifyTestCustomFor2(const std::shared_ptr<BaseTestStruct<AccResults<DataType>>>& args)
     {
         using namespace std::placeholders;
         auto checker = std::bind(&AccumulateTestFixture::verifyCustomFor2, this, _1, _2, _3, _4);

--- a/tests/2Accumulate/Matrix3/MatrixTests.cpp
+++ b/tests/2Accumulate/Matrix3/MatrixTests.cpp
@@ -7,23 +7,31 @@ namespace tests::Accumulate
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    MatrixAccumulateIntPrefix,
+    AccumulatePrefix,
     MatrixAccumulateIntFixture,
     ::testing::Values(
-        MatrixAccumulateArgs<int>(Examples::randomIntMatrix, MATRIX_COUNT, AccType::SumOnly),
-        MatrixAccumulateArgs<int>(Examples::randomIntMatrix, MATRIX_COUNT, AccType::SumAndExtremes),
-        MatrixAccumulateArgs<int>(Examples::randomIntMatrix, MATRIX_COUNT, AccType::SumAndMean),
-        MatrixAccumulateArgs<int>(Examples::randomIntMatrix, MATRIX_COUNT, AccType::DoItAll)
+        std::make_shared<MatrixAccumulateArgs<int>>(
+            Examples::randomIntMatrix, MATRIX_COUNT, AccType::SumOnly),
+        std::make_shared<MatrixAccumulateArgs<int>>(
+            Examples::randomIntMatrix, MATRIX_COUNT, AccType::SumAndExtremes),
+        std::make_shared<MatrixAccumulateArgs<int>>(
+            Examples::randomIntMatrix, MATRIX_COUNT, AccType::SumAndMean),
+        std::make_shared<MatrixAccumulateArgs<int>>(
+            Examples::randomIntMatrix, MATRIX_COUNT, AccType::DoItAll)
     ));
 
 INSTANTIATE_TEST_SUITE_P(
-    MatrixAccumulateDoublePrefix,
+    AccumulatePrefix,
     MatrixAccumulateDoubleFixture,
     ::testing::Values(
-        MatrixAccumulateArgs<double>(Examples::randomDoubleMatrix, MATRIX_COUNT, AccType::SumOnly),
-        MatrixAccumulateArgs<double>(Examples::randomDoubleMatrix, MATRIX_COUNT, AccType::SumAndExtremes),
-        MatrixAccumulateArgs<double>(Examples::randomDoubleMatrix, MATRIX_COUNT, AccType::SumAndMean),
-        MatrixAccumulateArgs<double>(Examples::randomDoubleMatrix, MATRIX_COUNT, AccType::DoItAll)
+        std::make_shared<MatrixAccumulateArgs<double>>(
+            Examples::randomDoubleMatrix, MATRIX_COUNT, AccType::SumOnly),
+        std::make_shared<MatrixAccumulateArgs<double>>(
+            Examples::randomDoubleMatrix, MATRIX_COUNT, AccType::SumAndExtremes),
+        std::make_shared<MatrixAccumulateArgs<double>>(
+            Examples::randomDoubleMatrix, MATRIX_COUNT, AccType::SumAndMean),
+        std::make_shared<MatrixAccumulateArgs<double>>(
+            Examples::randomDoubleMatrix, MATRIX_COUNT, AccType::DoItAll)
     ));
 
 } // namespace tests::Accumulate

--- a/tests/2Accumulate/Matrix3/MatrixTests.hpp
+++ b/tests/2Accumulate/Matrix3/MatrixTests.hpp
@@ -13,14 +13,18 @@ requires std::is_arithmetic_v<Number>
 struct MatrixAccumulateArgs final : public AccumulateTestStruct<Matrix<Number>>
 {
     explicit MatrixAccumulateArgs(
-        Matrix<Number>(*f)(),
+        Matrix<Number>(*dataCreator)(),
         const unsigned int n,
         AccType accType)
     : AccumulateTestStruct<Matrix<Number>>(
         TestType::AccumulateMatrix,
-        std::make_shared<Accumulator<Matrix<Number>>>(
-            this->template initTestData<std::vector<Matrix<Number>>>(f, n),
-            accType))
+        [dataCreator, n, accType]()
+        {
+            std::vector<Matrix<Number>> data =
+                BaseTestStruct<AccResults<Matrix<Number>>>::template
+                initTestData<std::vector<Matrix<Number>>>(dataCreator, n);
+            return std::make_shared<Accumulator<Matrix<Number>>>(std::move(data), accType);
+        })
     { }
 };
 

--- a/tests/2Accumulate/Points2/PointsTests.cpp
+++ b/tests/2Accumulate/Points2/PointsTests.cpp
@@ -7,43 +7,44 @@ namespace tests::Accumulate
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    PointsAccumulatePrefix,
+    AccumulatePrefix,
     PointsAccumulateFixture,
     ::testing::Values(
         // generator rosnacych liczb
-        PointsAccumulateArgs(PointsAccumulateFixture::sortedGenerator,
-                   SMALL_TEST, AccType::SumOnly),
-        PointsAccumulateArgs(PointsAccumulateFixture::sortedGenerator,
-                   SMALL_TEST, AccType::SumAndExtremes),
-        PointsAccumulateArgs(PointsAccumulateFixture::sortedGenerator,
-                   SMALL_TEST, AccType::SumAndMean),
-        PointsAccumulateArgs(PointsAccumulateFixture::sortedGenerator,
-                   SMALL_TEST, AccType::DoItAll),
-        PointsAccumulateArgs(PointsAccumulateFixture::sortedGenerator,
-                   MEDIUM_TEST, AccType::SumOnly),
-        PointsAccumulateArgs(PointsAccumulateFixture::sortedGenerator,
-                   MEDIUM_TEST, AccType::SumAndExtremes),
-        PointsAccumulateArgs(PointsAccumulateFixture::sortedGenerator,
-                   MEDIUM_TEST, AccType::SumAndMean),
-        PointsAccumulateArgs(PointsAccumulateFixture::sortedGenerator,
-                   MEDIUM_TEST, AccType::DoItAll),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::sortedGenerator, SMALL_TEST, AccType::SumOnly),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::sortedGenerator, SMALL_TEST, AccType::SumAndExtremes),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::sortedGenerator, SMALL_TEST, AccType::SumAndMean),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::sortedGenerator, SMALL_TEST, AccType::DoItAll),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::sortedGenerator, MEDIUM_TEST, AccType::SumOnly),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::sortedGenerator, MEDIUM_TEST, AccType::SumAndExtremes),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::sortedGenerator, MEDIUM_TEST, AccType::SumAndMean),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::sortedGenerator, MEDIUM_TEST, AccType::DoItAll),
+
         // generator malejacych liczb
-        PointsAccumulateArgs(PointsAccumulateFixture::reverseSortedGenerator,
-                   SMALL_TEST, AccType::SumOnly),
-        PointsAccumulateArgs(PointsAccumulateFixture::reverseSortedGenerator,
-                   SMALL_TEST, AccType::SumAndExtremes),
-        PointsAccumulateArgs(PointsAccumulateFixture::reverseSortedGenerator,
-                   SMALL_TEST, AccType::SumAndMean),
-        PointsAccumulateArgs(PointsAccumulateFixture::reverseSortedGenerator,
-                   SMALL_TEST, AccType::DoItAll),
-        PointsAccumulateArgs(PointsAccumulateFixture::reverseSortedGenerator,
-                   MEDIUM_TEST, AccType::SumOnly),
-        PointsAccumulateArgs(PointsAccumulateFixture::reverseSortedGenerator,
-                   MEDIUM_TEST, AccType::SumAndExtremes),
-        PointsAccumulateArgs(PointsAccumulateFixture::reverseSortedGenerator,
-                   MEDIUM_TEST, AccType::SumAndMean),
-        PointsAccumulateArgs(PointsAccumulateFixture::reverseSortedGenerator,
-                   MEDIUM_TEST, AccType::DoItAll)
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::reverseSortedGenerator, SMALL_TEST, AccType::SumOnly),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::reverseSortedGenerator, SMALL_TEST, AccType::SumAndExtremes),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::reverseSortedGenerator, SMALL_TEST, AccType::SumAndMean),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::reverseSortedGenerator, SMALL_TEST, AccType::DoItAll),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::reverseSortedGenerator, MEDIUM_TEST, AccType::SumOnly),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::reverseSortedGenerator, MEDIUM_TEST, AccType::SumAndExtremes),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::reverseSortedGenerator, MEDIUM_TEST, AccType::SumAndMean),
+        std::make_shared<PointsAccumulateArgs>(
+            PointsAccumulateFixture::reverseSortedGenerator, MEDIUM_TEST, AccType::DoItAll)
     ));
 
 } // namespace tests::Accumulate

--- a/tests/2Accumulate/Points2/PointsTests.hpp
+++ b/tests/2Accumulate/Points2/PointsTests.hpp
@@ -11,14 +11,17 @@ namespace tests::Accumulate
 struct PointsAccumulateArgs final : public AccumulateTestStruct<Point2D>
 {
     explicit PointsAccumulateArgs(
-        Point2D (*f)(const unsigned int),
+        Point2D (*dataCreator)(const unsigned int),
         const unsigned int n,
         AccType accType)
     : AccumulateTestStruct<Point2D>(
         TestType::AccumulatePoints,
-        std::make_shared<Accumulator<Point2D>>(
-            initTestData<std::vector<Point2D>>(f, n),
-            accType))
+        [dataCreator, n, accType]()
+        {
+            std::vector<Point2D> data =
+                initTestData<std::vector<Point2D>>(dataCreator, n);
+            return std::make_shared<Accumulator<Point2D>>(std::move(data), accType);
+        })
     { }
 };
 

--- a/tests/2Accumulate/UInt1/UIntTests.cpp
+++ b/tests/2Accumulate/UInt1/UIntTests.cpp
@@ -7,43 +7,44 @@ namespace tests::Accumulate
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    UIntAccumulatePrefix,
+    AccumulatePrefix,
     UIntAccumulateFixture,
     ::testing::Values(
         // generator rosnacych liczb
-        UIntAccumulateArgs(UIntAccumulateFixture::sortedGenerator,
-                   SMALL_TEST, AccType::SumOnly),
-        UIntAccumulateArgs(UIntAccumulateFixture::sortedGenerator,
-                   SMALL_TEST, AccType::SumAndExtremes),
-        UIntAccumulateArgs(UIntAccumulateFixture::sortedGenerator,
-                   SMALL_TEST, AccType::SumAndMean),
-        UIntAccumulateArgs(UIntAccumulateFixture::sortedGenerator,
-                   SMALL_TEST, AccType::DoItAll),
-        UIntAccumulateArgs(UIntAccumulateFixture::sortedGenerator,
-                   MEDIUM_TEST, AccType::SumOnly),
-        UIntAccumulateArgs(UIntAccumulateFixture::sortedGenerator,
-                   MEDIUM_TEST, AccType::SumAndExtremes),
-        UIntAccumulateArgs(UIntAccumulateFixture::sortedGenerator,
-                   MEDIUM_TEST, AccType::SumAndMean),
-        UIntAccumulateArgs(UIntAccumulateFixture::sortedGenerator,
-                   MEDIUM_TEST, AccType::DoItAll),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::sortedGenerator, SMALL_TEST, AccType::SumOnly),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::sortedGenerator, SMALL_TEST, AccType::SumAndExtremes),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::sortedGenerator, SMALL_TEST, AccType::SumAndMean),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::sortedGenerator, SMALL_TEST, AccType::DoItAll),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::sortedGenerator, MEDIUM_TEST, AccType::SumOnly),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::sortedGenerator, MEDIUM_TEST, AccType::SumAndExtremes),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::sortedGenerator, MEDIUM_TEST, AccType::SumAndMean),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::sortedGenerator, MEDIUM_TEST, AccType::DoItAll),
+
         // generator malejacych liczb
-        UIntAccumulateArgs(UIntAccumulateFixture::reverseSortedGenerator,
-                   SMALL_TEST, AccType::SumOnly),
-        UIntAccumulateArgs(UIntAccumulateFixture::reverseSortedGenerator,
-                   SMALL_TEST, AccType::SumAndExtremes),
-        UIntAccumulateArgs(UIntAccumulateFixture::reverseSortedGenerator,
-                   SMALL_TEST, AccType::SumAndMean),
-        UIntAccumulateArgs(UIntAccumulateFixture::reverseSortedGenerator,
-                   SMALL_TEST, AccType::DoItAll),
-        UIntAccumulateArgs(UIntAccumulateFixture::reverseSortedGenerator,
-                   MEDIUM_TEST, AccType::SumOnly),
-        UIntAccumulateArgs(UIntAccumulateFixture::reverseSortedGenerator,
-                   MEDIUM_TEST, AccType::SumAndExtremes),
-        UIntAccumulateArgs(UIntAccumulateFixture::reverseSortedGenerator,
-                   MEDIUM_TEST, AccType::SumAndMean),
-        UIntAccumulateArgs(UIntAccumulateFixture::reverseSortedGenerator,
-                   MEDIUM_TEST, AccType::DoItAll)
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::reverseSortedGenerator, SMALL_TEST, AccType::SumOnly),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::reverseSortedGenerator, SMALL_TEST, AccType::SumAndExtremes),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::reverseSortedGenerator, SMALL_TEST, AccType::SumAndMean),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::reverseSortedGenerator, SMALL_TEST, AccType::DoItAll),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::reverseSortedGenerator, MEDIUM_TEST, AccType::SumOnly),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::reverseSortedGenerator, MEDIUM_TEST, AccType::SumAndExtremes),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::reverseSortedGenerator, MEDIUM_TEST, AccType::SumAndMean),
+        std::make_shared<UIntAccumulateArgs>(
+            UIntAccumulateFixture::reverseSortedGenerator, MEDIUM_TEST, AccType::DoItAll)
     ));
 
 } // namespace tests::Accumulate

--- a/tests/2Accumulate/UInt1/UIntTests.hpp
+++ b/tests/2Accumulate/UInt1/UIntTests.hpp
@@ -8,14 +8,17 @@ namespace tests::Accumulate
 struct UIntAccumulateArgs final : public AccumulateTestStruct<unsigned int>
 {
     explicit UIntAccumulateArgs(
-        unsigned int (*f)(const unsigned int),
+        unsigned int (*dataCreator)(const unsigned int),
         const unsigned int n,
         AccType accType)
     : AccumulateTestStruct<unsigned int>(
         TestType::AccumulateUint,
-        std::make_shared<Accumulator<unsigned int>>(
-            initTestData<std::vector<unsigned int>>(f, n),
-            accType))
+        [dataCreator, n, accType]()
+        {
+            std::vector<unsigned int> data =
+                initTestData<std::vector<unsigned int>>(dataCreator, n);
+            return std::make_shared<Accumulator<unsigned int>>(std::move(data), accType);
+        })
     { }
 };
 

--- a/tests/3Merge/MergeTestFixture.hpp
+++ b/tests/3Merge/MergeTestFixture.hpp
@@ -13,13 +13,13 @@ struct MergeTestStruct : public BaseTestStruct<std::vector<DataType>>
 {
 protected:
     explicit MergeTestStruct(const TestType testType,
-        std::shared_ptr<Merger<DataType>>&& f)
-    : BaseTestStruct<std::vector<DataType>>(testType, std::move(f))
+        Callback<Merger<DataType>>&& callback)
+    : BaseTestStruct<std::vector<DataType>>(testType, std::move(callback))
     { }
 
-    static MergerData<DataType> initTestData3(
-        DataType (*fun1)(const unsigned int),
-        DataType (*fun2)(const unsigned int),
+    static std::shared_ptr<Merger<DataType>> initTestData3(
+        DataType (*dataCreator1)(const unsigned int),
+        DataType (*dataCreator2)(const unsigned int),
         const unsigned int n1,
         const unsigned int n2)
     {
@@ -30,13 +30,14 @@ protected:
 
         for (unsigned int i = 1; i <= n1; ++i)
         {
-            v1.emplace_back(fun1(i));
+            v1.emplace_back(dataCreator1(i));
         }
         for (unsigned int i = 1; i <= n2; ++i)
         {
-            v2.emplace_back(fun2(i));
+            v2.emplace_back(dataCreator2(i));
         }
-        return MergerData<DataType>(v1, v2);
+        MergerData<DataType> data(v1, v2);
+        return std::make_shared<Merger<DataType>>(std::move(data));
     }
 };
 

--- a/tests/3Merge/Points1/PointsTests.cpp
+++ b/tests/3Merge/Points1/PointsTests.cpp
@@ -4,18 +4,21 @@ namespace tests::Merge
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    PointsMergePrefix,
+    MergePrefix,
     PointsMergeFixture,
     ::testing::Values(
-        PointsMergeArgs(PointsMergeFixture::fmod3i3_mod7i64,
-                   PointsMergeFixture::f3i_mod9i64,
-                   300'000, 200'000),
-        PointsMergeArgs(PointsMergeFixture::fmod3i3_mod7i64,
-                   PointsMergeFixture::f3i_mod9i64,
-                   700'000, 300'000),
-        PointsMergeArgs(PointsMergeFixture::fmod3i3_mod7i64,
-                   PointsMergeFixture::f3i_mod9i64,
-                   1'000'000, 600'000)
+        std::make_shared<PointsMergeArgs>(
+            PointsMergeFixture::fmod3i3_mod7i64,
+            PointsMergeFixture::f3i_mod9i64,
+            300'000, 200'000),
+        std::make_shared<PointsMergeArgs>(
+            PointsMergeFixture::fmod3i3_mod7i64,
+            PointsMergeFixture::f3i_mod9i64,
+            700'000, 300'000),
+        std::make_shared<PointsMergeArgs>(
+            PointsMergeFixture::fmod3i3_mod7i64,
+            PointsMergeFixture::f3i_mod9i64,
+            1'000'000, 600'000)
     ));
 
 } // namespace tests::Merge

--- a/tests/3Merge/Points1/PointsTests.hpp
+++ b/tests/3Merge/Points1/PointsTests.hpp
@@ -11,13 +11,16 @@ namespace tests::Merge
 struct PointsMergeArgs final : public MergeTestStruct<Point2D>
 {
     explicit PointsMergeArgs(
-        Point2D (*fun1)(const unsigned int),
-        Point2D (*fun2)(const unsigned int),
+        Point2D (*dataCreator1)(const unsigned int),
+        Point2D (*dataCreator2)(const unsigned int),
         const unsigned int n1,
         const unsigned int n2)
     : MergeTestStruct<Point2D>(
         TestType::MergePoints,
-        std::make_shared<Merger<Point2D>>(initTestData3(fun1, fun2, n1, n2)))
+        [dataCreator1, dataCreator2, n1, n2]()
+        {
+            return initTestData3(dataCreator1, dataCreator2, n1, n2);
+        })
     { }
 };
 

--- a/tests/3Merge/Vector3/IntVectorTests.cpp
+++ b/tests/3Merge/Vector3/IntVectorTests.cpp
@@ -4,27 +4,33 @@ namespace tests::Merge
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    IntVectorMergePrefix,
+    MergePrefix,
     IntVectorMergeFixture,
     ::testing::Values(
-        IntVectorMergeArgs(IntVectorMergeFixture::f10i_imod7,
-                      IntVectorMergeFixture::f10i_imod9,
-                      3000, 3000),
-        IntVectorMergeArgs(IntVectorMergeFixture::f10i_imod7,
-                      IntVectorMergeFixture::f10i_imod9,
-                      4000, 2000),
-        IntVectorMergeArgs(IntVectorMergeFixture::f10i_imod7,
-                      IntVectorMergeFixture::f10i_imod9,
-                      5000, 1000),
-        IntVectorMergeArgs(IntVectorMergeFixture::f10i_imod7,
-                      IntVectorMergeFixture::f10i_imod9,
-                      5400, 5400),
-        IntVectorMergeArgs(IntVectorMergeFixture::f10i_imod7,
-                      IntVectorMergeFixture::f10i_imod9,
-                      7400, 3400),
-        IntVectorMergeArgs(IntVectorMergeFixture::f10i_imod7,
-                      IntVectorMergeFixture::f10i_imod9,
-                      9400, 1400)
+        std::make_shared<IntVectorMergeArgs>(
+            IntVectorMergeFixture::f10i_imod7,
+            IntVectorMergeFixture::f10i_imod9,
+            3000, 3000),
+        std::make_shared<IntVectorMergeArgs>(
+            IntVectorMergeFixture::f10i_imod7,
+            IntVectorMergeFixture::f10i_imod9,
+            4000, 2000),
+        std::make_shared<IntVectorMergeArgs>(
+            IntVectorMergeFixture::f10i_imod7,
+            IntVectorMergeFixture::f10i_imod9,
+            5000, 1000),
+        std::make_shared<IntVectorMergeArgs>(
+            IntVectorMergeFixture::f10i_imod7,
+            IntVectorMergeFixture::f10i_imod9,
+            5400, 5400),
+        std::make_shared<IntVectorMergeArgs>(
+            IntVectorMergeFixture::f10i_imod7,
+            IntVectorMergeFixture::f10i_imod9,
+            7400, 3400),
+        std::make_shared<IntVectorMergeArgs>(
+            IntVectorMergeFixture::f10i_imod7,
+            IntVectorMergeFixture::f10i_imod9,
+            9400, 1400)
     ));
 
 } // namespace tests::Merge

--- a/tests/3Merge/Vector3/IntVectorTests.hpp
+++ b/tests/3Merge/Vector3/IntVectorTests.hpp
@@ -11,13 +11,16 @@ namespace tests::Merge
 struct IntVectorMergeArgs final : public MergeTestStruct<IntVector>
 {
     explicit IntVectorMergeArgs(
-        IntVector (*fun1)(const unsigned int),
-        IntVector (*fun2)(const unsigned int),
+        IntVector (*dataCreator1)(const unsigned int),
+        IntVector (*dataCreator2)(const unsigned int),
         const unsigned int n1,
         const unsigned int n2)
     : MergeTestStruct<IntVector>(
         TestType::MergeIntVector,
-        std::make_shared<Merger<IntVector>>(initTestData3(fun1, fun2, n1, n2)))
+        [dataCreator1, dataCreator2, n1, n2]()
+        {
+            return initTestData3(dataCreator1, dataCreator2, n1, n2);
+        })
     { }
 };
 

--- a/tests/4Sort/Points1/PointsTests.cpp
+++ b/tests/4Sort/Points1/PointsTests.cpp
@@ -8,18 +8,18 @@ namespace tests::Sort
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    PointsSortPrefix,
+    SortPrefix,
     PointsSortFixture,
     ::testing::Values(
-        PointsSortArgs(PointsSortFixture::sortedGenerator, SMALL_TEST),
-        PointsSortArgs(PointsSortFixture::sortedGenerator, MEDIUM_TEST),
-        PointsSortArgs(PointsSortFixture::sortedGenerator, BIG_TEST),
-        PointsSortArgs(PointsSortFixture::reverseSortedGenerator, SMALL_TEST),
-        PointsSortArgs(PointsSortFixture::reverseSortedGenerator, MEDIUM_TEST),
-        PointsSortArgs(PointsSortFixture::reverseSortedGenerator, BIG_TEST),
-        PointsSortArgs(PointsSortFixture::randomGenerator, SMALL_TEST),
-        PointsSortArgs(PointsSortFixture::randomGenerator, MEDIUM_TEST),
-        PointsSortArgs(PointsSortFixture::randomGenerator, BIG_TEST)
+        std::make_shared<PointsSortArgs>(PointsSortFixture::sortedGenerator, SMALL_TEST),
+        std::make_shared<PointsSortArgs>(PointsSortFixture::sortedGenerator, MEDIUM_TEST),
+        std::make_shared<PointsSortArgs>(PointsSortFixture::sortedGenerator, BIG_TEST),
+        std::make_shared<PointsSortArgs>(PointsSortFixture::reverseSortedGenerator, SMALL_TEST),
+        std::make_shared<PointsSortArgs>(PointsSortFixture::reverseSortedGenerator, MEDIUM_TEST),
+        std::make_shared<PointsSortArgs>(PointsSortFixture::reverseSortedGenerator, BIG_TEST),
+        std::make_shared<PointsSortArgs>(PointsSortFixture::randomGenerator, SMALL_TEST),
+        std::make_shared<PointsSortArgs>(PointsSortFixture::randomGenerator, MEDIUM_TEST),
+        std::make_shared<PointsSortArgs>(PointsSortFixture::randomGenerator, BIG_TEST)
     ));
 
 } // namespace tests::Sort

--- a/tests/4Sort/Points1/PointsTests.hpp
+++ b/tests/4Sort/Points1/PointsTests.hpp
@@ -10,16 +10,26 @@ namespace tests::Sort
 
 struct PointsSortArgs final : public SortTestStruct<Point2D>
 {
-    explicit PointsSortArgs(Point2D (*f)(), const unsigned int n)
+    explicit PointsSortArgs(Point2D (*dataCreator)(), const unsigned int n)
     : SortTestStruct<Point2D>(
         TestType::SortPoints,
-        std::make_shared<Sorter<Point2D>>(initTestData<std::vector<Point2D>>(f, n)))
+        [dataCreator, n]()
+        {
+            std::vector<Point2D> data =
+                initTestData<std::vector<Point2D>>(dataCreator, n);
+            return std::make_shared<Sorter<Point2D>>(std::move(data));
+        })
     { }
 
-    PointsSortArgs(Point2D (*f)(const unsigned int), const unsigned int n)
+    PointsSortArgs(Point2D (*dataCreator)(const unsigned int), const unsigned int n)
     : SortTestStruct<Point2D>(
         TestType::SortPoints,
-        std::make_shared<Sorter<Point2D>>(initTestData<std::vector<Point2D>>(f, n)))
+        [dataCreator, n]()
+        {
+            std::vector<Point2D> data =
+                initTestData<std::vector<Point2D>>(dataCreator, n);
+            return std::make_shared<Sorter<Point2D>>(std::move(data));
+        })
     { }
 };
 

--- a/tests/4Sort/SortTestFixture.hpp
+++ b/tests/4Sort/SortTestFixture.hpp
@@ -15,8 +15,8 @@ struct SortTestStruct : public BaseTestStruct<std::vector<DataType>>
 {
 protected:
     explicit SortTestStruct(const TestType testType,
-        std::shared_ptr<Sorter<DataType>>&& f)
-    : BaseTestStruct<std::vector<DataType>>(testType, std::move(f))
+        Callback<Sorter<DataType>>&& callback)
+    : BaseTestStruct<std::vector<DataType>>(testType, std::move(callback))
     { }
 };
 

--- a/tests/4Sort/Vector3/IntVectorTests.cpp
+++ b/tests/4Sort/Vector3/IntVectorTests.cpp
@@ -8,18 +8,18 @@ namespace tests::Sort
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    IntVectorSortPrefix,
+    SortPrefix,
     IntVectorSortFixture,
     ::testing::Values(
-        IntVectorSortArgs(IntVectorSortFixture::sortedFirstElementGenerator, SMALL_TEST),
-        IntVectorSortArgs(IntVectorSortFixture::sortedFirstElementGenerator, MEDIUM_TEST),
-        IntVectorSortArgs(IntVectorSortFixture::sortedFirstElementGenerator, BIG_TEST),
-        IntVectorSortArgs(IntVectorSortFixture::sortedLastElementGenerator, SMALL_TEST),
-        IntVectorSortArgs(IntVectorSortFixture::sortedLastElementGenerator, MEDIUM_TEST),
-        IntVectorSortArgs(IntVectorSortFixture::sortedLastElementGenerator, BIG_TEST),
-        IntVectorSortArgs(IntVectorSortFixture::randomGenerator, SMALL_TEST),
-        IntVectorSortArgs(IntVectorSortFixture::randomGenerator, MEDIUM_TEST),
-        IntVectorSortArgs(IntVectorSortFixture::randomGenerator, BIG_TEST)
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::sortedFirstElementGenerator, SMALL_TEST),
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::sortedFirstElementGenerator, MEDIUM_TEST),
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::sortedFirstElementGenerator, BIG_TEST),
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::sortedLastElementGenerator, SMALL_TEST),
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::sortedLastElementGenerator, MEDIUM_TEST),
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::sortedLastElementGenerator, BIG_TEST),
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::randomGenerator, SMALL_TEST),
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::randomGenerator, MEDIUM_TEST),
+        std::make_shared<IntVectorSortArgs>(IntVectorSortFixture::randomGenerator, BIG_TEST)
     ));
 
 } // namespace tests::Sort

--- a/tests/4Sort/Vector3/IntVectorTests.hpp
+++ b/tests/4Sort/Vector3/IntVectorTests.hpp
@@ -11,11 +11,16 @@ namespace tests::Sort
 struct IntVectorSortArgs final : public SortTestStruct<IntVector>
 {
     explicit IntVectorSortArgs(
-        IntVector (*f)(const unsigned int),
+        IntVector (*dataCreator)(const unsigned int),
         const unsigned int n)
     : SortTestStruct<IntVector>(
         TestType::SortIntVector,
-        std::make_shared<Sorter<IntVector>>(initTestData<std::vector<IntVector>>(f, n)))
+        [dataCreator, n]()
+        {
+            std::vector<IntVector> data =
+                initTestData<std::vector<IntVector>>(dataCreator, n);
+            return std::make_shared<Sorter<IntVector>>(std::move(data));
+        })
     { }
 };
 

--- a/tests/5Transform/MatrixToIntVector1/TransformTests.cpp
+++ b/tests/5Transform/MatrixToIntVector1/TransformTests.cpp
@@ -8,14 +8,14 @@ namespace tests::Transform
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    MatrixToIntVectorTransformPrefix,
+    TransformPrefix,
     MatrixToIntVectorTransformFixture,
     ::testing::Values(
-        MatrixToIntVectorTransformArgs(
+        std::make_shared<MatrixToIntVectorTransformArgs>(
             MatrixToIntVectorTransformFixture::sortedFirstElementGenerator, SMALL_TEST),
-        MatrixToIntVectorTransformArgs(
+        std::make_shared<MatrixToIntVectorTransformArgs>(
             MatrixToIntVectorTransformFixture::sortedFirstElementGenerator, MEDIUM_TEST),
-        MatrixToIntVectorTransformArgs(
+        std::make_shared<MatrixToIntVectorTransformArgs>(
             MatrixToIntVectorTransformFixture::sortedFirstElementGenerator, BIG_TEST)
     ));
 

--- a/tests/5Transform/MatrixToIntVector1/TransformTests.hpp
+++ b/tests/5Transform/MatrixToIntVector1/TransformTests.hpp
@@ -12,13 +12,18 @@ namespace tests::Transform
 struct MatrixToIntVectorTransformArgs final : public TransformTestStruct<Matrix<int>, std::vector<IntVector>>
 {
     explicit MatrixToIntVectorTransformArgs(
-        Matrix<int> (*f)(const unsigned int),
+        Matrix<int> (*dataCreator)(const unsigned int),
         const unsigned int n)
     : TransformTestStruct<Matrix<int>, std::vector<IntVector>>(
         TestType::TransformMatrixToIntVector,
-        std::make_shared<Transformer<Matrix<int>, std::vector<IntVector>>>(
-            initTestData<std::vector<Matrix<int>>>(f, n),
-            &transformer))
+        [dataCreator, n]()
+        {
+            std::vector<Matrix<int>> inData =
+                initTestData<std::vector<Matrix<int>>>(dataCreator, n);
+            return std::make_shared<Transformer<Matrix<int>, std::vector<IntVector>>>(
+                std::move(inData),
+                &transformer);
+        })
     { }
 
     static std::vector<IntVector> transformer(const Matrix<int>& matrix)

--- a/tests/5Transform/TransformTestFixture.hpp
+++ b/tests/5Transform/TransformTestFixture.hpp
@@ -13,8 +13,8 @@ struct TransformTestStruct : public BaseTestStruct<std::vector<ReturnDataType>>
 {
 protected:
     explicit TransformTestStruct(const TestType testType,
-        std::shared_ptr<Transformer<InDataType, ReturnDataType>>&& f)
-    : BaseTestStruct<std::vector<ReturnDataType>>(testType, std::move(f))
+        Callback<Transformer<InDataType, ReturnDataType>>&& callback)
+    : BaseTestStruct<std::vector<ReturnDataType>>(testType, std::move(callback))
     { }
 };
 

--- a/tests/7NthElement/NthElementTestFixture.hpp
+++ b/tests/7NthElement/NthElementTestFixture.hpp
@@ -17,11 +17,11 @@ protected:
 
     explicit NthElementTestStruct(
         const TestType testType,
-        std::shared_ptr<NthFinder<Container>>&& f)
-    : BaseTestStruct<Container>(testType, std::move(f))
+        Callback<NthFinder<Container>>&& callback)
+    : BaseTestStruct<Container>(testType, std::move(callback))
     { }
 
-    static NthFinderData<Container> initTestData7(
+    static std::shared_ptr<NthFinder<Container>> initTestData7(
         DataType(*generator)(const unsigned int),
         const unsigned int n,
         const unsigned int vectorSize)
@@ -36,7 +36,8 @@ protected:
             elements.emplace_back(generator(i));
         }
 
-        return NthFinderData<Container>(elements, n);
+        NthFinderData<Container> data(std::move(elements), n);
+        return std::make_shared<NthFinder<Container>>(std::move(data));
     }
 };
 
@@ -47,10 +48,10 @@ class NthElementTestFixture : public BaseTestFixture<Container>
 protected:
     using DataType = typename Container::value_type;
 
-    void VerifyTestCustomFor7(const BaseTestStruct<Container>& args)
+    void VerifyTestCustomFor7(const std::shared_ptr<BaseTestStruct<Container>>& args)
     {
         using namespace std::placeholders;
-        const std::size_t n = args.getField(&NthFinder<Container>::n_);
+        const std::size_t n = args->getField(&NthFinder<Container>::n_);
         auto checker = std::bind(&NthElementTestFixture::verifyCustomFor7, this, _1, _2, _3, _4, n);
         this->VerifyTest(args, checker);
     }

--- a/tests/7NthElement/Points1/PointsTests.cpp
+++ b/tests/7NthElement/Points1/PointsTests.cpp
@@ -13,22 +13,32 @@ namespace tests::NthElement
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    PointsNthElementPrefix,
+    NthElementPrefix,
     PointsNthElementFixture,
     ::testing::Values(
         // Mala ilosc punktow
-        PointsNthElementArgs(PointsNthElementFixture::fmod3i3_mod7i64, SMALL_N, FEW_POINTS),
-        PointsNthElementArgs(PointsNthElementFixture::f3i_mod9i64, SMALL_N, FEW_POINTS),
-        PointsNthElementArgs(PointsNthElementFixture::fmod3i3_mod7i64, MEDIUM_N, FEW_POINTS),
-        PointsNthElementArgs(PointsNthElementFixture::f3i_mod9i64, MEDIUM_N, FEW_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::fmod3i3_mod7i64, SMALL_N, FEW_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::f3i_mod9i64, SMALL_N, FEW_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::fmod3i3_mod7i64, MEDIUM_N, FEW_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::f3i_mod9i64, MEDIUM_N, FEW_POINTS),
         // Srednia ilosc punktow
-        PointsNthElementArgs(PointsNthElementFixture::fmod3i3_mod7i64, MEDIUM_N, MEDIUM_POINTS),
-        PointsNthElementArgs(PointsNthElementFixture::f3i_mod9i64, MEDIUM_N, MEDIUM_POINTS),
-        PointsNthElementArgs(PointsNthElementFixture::fmod3i3_mod7i64, BIG_N, MEDIUM_POINTS),
-        PointsNthElementArgs(PointsNthElementFixture::f3i_mod9i64, BIG_N, MEDIUM_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::fmod3i3_mod7i64, MEDIUM_N, MEDIUM_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::f3i_mod9i64, MEDIUM_N, MEDIUM_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::fmod3i3_mod7i64, BIG_N, MEDIUM_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::f3i_mod9i64, BIG_N, MEDIUM_POINTS),
         // Duza ilosc punktow
-        PointsNthElementArgs(PointsNthElementFixture::fmod3i3_mod7i64, BIG_N, MANY_POINTS),
-        PointsNthElementArgs(PointsNthElementFixture::fmod3i3_mod7i64, HUGE_N, MANY_POINTS)
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::fmod3i3_mod7i64, BIG_N, MANY_POINTS),
+        std::make_shared<PointsNthElementArgs>(
+            PointsNthElementFixture::fmod3i3_mod7i64, HUGE_N, MANY_POINTS)
     ));
 
 } // namespace tests::NthElement

--- a/tests/7NthElement/Points1/PointsTests.hpp
+++ b/tests/7NthElement/Points1/PointsTests.hpp
@@ -11,12 +11,15 @@ namespace tests::NthElement
 struct PointsNthElementArgs final : public NthElementTestStruct<std::vector<Point2D>>
 {
     explicit PointsNthElementArgs(
-        Point2D (*fun)(const unsigned int),
+        Point2D (*dataCreator)(const unsigned int),
         const unsigned int n,
         const unsigned int vectorSize)
     : NthElementTestStruct<std::vector<Point2D>>(
         TestType::NthElementPoints,
-        std::make_shared<NthFinder<std::vector<Point2D>>>(initTestData7(fun, n, vectorSize)))
+        [dataCreator, n, vectorSize]()
+        {
+            return initTestData7(dataCreator, n, vectorSize);
+        })
     { }
 };
 

--- a/tests/7NthElement/RandomString2/RandomStringTests.cpp
+++ b/tests/7NthElement/RandomString2/RandomStringTests.cpp
@@ -15,18 +15,18 @@ namespace tests::NthElement
 {
 
 INSTANTIATE_TEST_SUITE_P(
-    RandomStringNthElementPrefix,
+    NthElementPrefix,
     RandomStringNthElementFixture,
     ::testing::Values(
         // Mala ilosc napisow
-        RandomStringNthElementArgs(SMALL_N, FEW_STRINGS, STRING_LENGTH),
-        RandomStringNthElementArgs(MEDIUM_N, FEW_STRINGS, STRING_LENGTH),
+        std::make_shared<RandomStringNthElementArgs>(SMALL_N, FEW_STRINGS, STRING_LENGTH),
+        std::make_shared<RandomStringNthElementArgs>(MEDIUM_N, FEW_STRINGS, STRING_LENGTH),
         // Srednia ilosc napisow
-        RandomStringNthElementArgs(MEDIUM_N, MEDIUM_STRINGS, STRING_LENGTH),
-        RandomStringNthElementArgs(BIG_N, MEDIUM_STRINGS, STRING_LENGTH),
+        std::make_shared<RandomStringNthElementArgs>(MEDIUM_N, MEDIUM_STRINGS, STRING_LENGTH),
+        std::make_shared<RandomStringNthElementArgs>(BIG_N, MEDIUM_STRINGS, STRING_LENGTH),
         // Duza ilosc napisow
-        RandomStringNthElementArgs(BIG_N, MANY_STRINGS, STRING_LENGTH),
-        RandomStringNthElementArgs(HUGE_N, MANY_STRINGS, STRING_LENGTH)
+        std::make_shared<RandomStringNthElementArgs>(BIG_N, MANY_STRINGS, STRING_LENGTH),
+        std::make_shared<RandomStringNthElementArgs>(HUGE_N, MANY_STRINGS, STRING_LENGTH)
     ));
 
 } // namespace tests::NthElement

--- a/tests/7NthElement/RandomString2/RandomStringTests.hpp
+++ b/tests/7NthElement/RandomString2/RandomStringTests.hpp
@@ -16,7 +16,10 @@ struct RandomStringNthElementArgs final : public NthElementTestStruct<std::vecto
         const unsigned int stringLength)
     : NthElementTestStruct<std::vector<std::string>>(
         TestType::NthElementRandomString,
-        RandomStringImpl::createFinder(n, vectorSize, stringLength))
+        [n, vectorSize, stringLength]()
+        {
+            return RandomStringImpl::createFinder(n, vectorSize, stringLength);
+        })
     { }
 };
 

--- a/tests/8Regex/RegexTests.cpp
+++ b/tests/8Regex/RegexTests.cpp
@@ -10,10 +10,10 @@ INSTANTIATE_TEST_SUITE_P(
     RegexPrefix,
     RegexTestFixture,
     ::testing::Values(
-        RegexTestStruct(SMALL_TEXT_SIZE, ERegexTestType::date),
-        RegexTestStruct(MEDIUM_TEXT_SIZE, ERegexTestType::date),
-        RegexTestStruct(SMALL_TEXT_SIZE, ERegexTestType::phone),
-        RegexTestStruct(MEDIUM_TEXT_SIZE, ERegexTestType::phone)
+        std::make_shared<RegexTestStruct>(SMALL_TEXT_SIZE, ERegexTestType::date),
+        std::make_shared<RegexTestStruct>(MEDIUM_TEXT_SIZE, ERegexTestType::date),
+        std::make_shared<RegexTestStruct>(SMALL_TEXT_SIZE, ERegexTestType::phone),
+        std::make_shared<RegexTestStruct>(MEDIUM_TEXT_SIZE, ERegexTestType::phone)
     ));
 
 } // namespace tests::Regex

--- a/tests/8Regex/RegexTests.hpp
+++ b/tests/8Regex/RegexTests.hpp
@@ -19,11 +19,13 @@ struct RegexTestStruct final : public BaseTestStruct<std::vector<std::string>>
 {
 public:
     explicit RegexTestStruct(const unsigned int textLength, const ERegexTestType testType)
-    : BaseTestStruct<std::vector<std::string>>(TestType::RegexType, createEvaluatorPtr(textLength, testType))
+    : BaseTestStruct<std::vector<std::string>>(TestType::RegexType,
+        [textLength, testType]()
+        { return initTestData8(textLength, testType); })
     { }
 
 private:
-    static std::shared_ptr<RegexEvaluator> createEvaluatorPtr(
+    static std::shared_ptr<RegexEvaluator> initTestData8(
         const unsigned int textLength, const ERegexTestType testType)
     {
         std::string(*textGenerator)(const unsigned int);

--- a/tests/9RemoveEraseIf/RemoveEraseIfTestFixture.hpp
+++ b/tests/9RemoveEraseIf/RemoveEraseIfTestFixture.hpp
@@ -16,11 +16,11 @@ protected:
     using DataType = typename Container::value_type;
 
     explicit RemoveEraseIfTestStruct(const TestType testType,
-        std::shared_ptr<Remover<Container>>&& f)
-    : BaseTestStruct<Container>(testType, std::move(f))
+        Callback<Remover<Container>>&& callback)
+    : BaseTestStruct<Container>(testType, std::move(callback))
     { }
 
-    static RemoverData<Container> initTestData(
+    static std::shared_ptr<Remover<Container>> initTestData9(
         DataType(*generator)(const unsigned int),
         bool (*predicate)(const DataType&),
         const unsigned int n)
@@ -33,7 +33,8 @@ protected:
             elements.emplace_back(generator(i));
         }
 
-        return RemoverData<Container>(elements, predicate);
+        RemoverData<Container> data(std::move(elements), predicate);
+        return std::make_shared<Remover<Container>>(std::move(data));
     }
 };
 

--- a/tests/9RemoveEraseIf/Sequence1/SequenceTests.cpp
+++ b/tests/9RemoveEraseIf/Sequence1/SequenceTests.cpp
@@ -11,9 +11,9 @@ INSTANTIATE_TEST_SUITE_P(
     SequencePrefix,
     SequenceIntFixture,
     ::testing::Values(
-        SequenceArgs(MERSENNE_TEST_SIZE, SequenceIntFixture::isMersenneNumber),
-        SequenceArgs(DIVISORS_TEST_SIZE, SequenceIntFixture::hasAtMost4Divisors),
-        SequenceArgs(SUM_TEST_SIZE, SequenceIntFixture::is1toNSumOdd)
+        std::make_shared<SequenceArgs>(MERSENNE_TEST_SIZE, SequenceIntFixture::isMersenneNumber),
+        std::make_shared<SequenceArgs>(DIVISORS_TEST_SIZE, SequenceIntFixture::hasAtMost4Divisors),
+        std::make_shared<SequenceArgs>(SUM_TEST_SIZE, SequenceIntFixture::is1toNSumOdd)
     ));
 
 } // namespace tests::RemoveEraseIf

--- a/tests/9RemoveEraseIf/Sequence1/SequenceTests.hpp
+++ b/tests/9RemoveEraseIf/Sequence1/SequenceTests.hpp
@@ -14,27 +14,23 @@ struct SequenceArgs final : public RemoveEraseIfTestStruct<std::vector<unsigned 
         bool(*predicate)(const unsigned int&))
     : RemoveEraseIfTestStruct<std::vector<unsigned int>>(
         TestType::RemoveEraseIfSequence,
-        std::make_shared<Remover<std::vector<unsigned int>>>(
-            RemoverData<std::vector<unsigned int>>(initData(n), predicate)))
+        [n, predicate]()
+        {
+            std::vector<unsigned int> data(n);
+            std::iota(data.begin(), data.end(), 0);
+            return initTestData9(identity, predicate, n);
+        })
     { }
 
-private:
-    static std::vector<unsigned int> initData(const unsigned int n)
+    static unsigned int identity(const unsigned int n)
     {
-        std::vector<unsigned int> data(n);
-        std::iota(data.begin(), data.end(), 0);
-        return data;
+        return n;
     }
 };
 
 class SequenceIntFixture : public RemoveEraseIfTestFixture<std::vector<unsigned int>>
 {
 public:
-    static unsigned int identity(const unsigned int n)
-    {
-        return n;
-    }
-
     // predykaty
     static bool isNotPrime(const unsigned int value)
     {

--- a/tests/Path.hpp
+++ b/tests/Path.hpp
@@ -32,46 +32,47 @@ enum class TestType : unsigned char
     GenerateMatrix
 };
 
+std::ostream& operator<<(std::ostream& os, const TestType& testType)
+{
+    switch (testType)
+    {
+        case TestType::MinMaxBasicVector:           return os << "BasicVector";
+        case TestType::MinMaxVectorOfVectors:       return os << "VectorOfVectors";
+        case TestType::MinMaxBasicSet:              return os << "BasicSet";
+        case TestType::MinMaxVectorSet:             return os << "VectorSet";
+        case TestType::AccumulateUint:              return os << "UInt";
+        case TestType::AccumulatePoints:            return os << "Points";
+        case TestType::AccumulateMatrix:            return os << "Matrix";
+        case TestType::MergePoints:                 return os << "Points";
+        case TestType::MergeIntVector:              return os << "IntVector";
+        case TestType::SortPoints:                  return os << "Points";
+        case TestType::SortIntVector:               return os << "IntVector";
+        // TODO: wiecej typow 5
+        case TestType::TransformMatrixToIntVector:  return os << "MatrixToIntVector";
+        // TODO: typy 6
+        case TestType::NthElementPoints:            return os << "Points";
+        case TestType::NthElementRandomString:      return os << "RandomString";
+        case TestType::RegexType:                   return os << "Regex";
+        // TODO: wiecej typow 9
+        case TestType::RemoveEraseIfSequence:       return os << "Sequence";
+        case TestType::GenerateFibonacci:           return os << "Fibonacci";
+        case TestType::GenerateRandomString:        return os << "RandomString";
+        case TestType::GenerateMatrix:              return os << "Matrix";
+        default:                                    return os << "!!! Nieznany typ testu !!!";
+    }
+}
+
 class Path final
 {
 public:
     Path() = delete;
 
-    static std::string Create(const TestType testType)
+    static std::string Create(const TestType& testType)
     {
         static std::unordered_map<TestType, unsigned int> testIdMap;
-        return Convert(testType) + std::to_string(++testIdMap[testType]) + ".txt";
-    }
-
-private:
-    static std::string Convert(const TestType testType)
-    {
-        switch (testType)
-        {
-            case TestType::MinMaxBasicVector:           return "BasicVector";
-            case TestType::MinMaxVectorOfVectors:       return "VectorOfVectors";
-            case TestType::MinMaxBasicSet:              return "BasicSet";
-            case TestType::MinMaxVectorSet:             return "VectorSet";
-            case TestType::AccumulateUint:              return "UInt";
-            case TestType::AccumulatePoints:            return "Points";
-            case TestType::AccumulateMatrix:            return "Matrix";
-            case TestType::MergePoints:                 return "Points";
-            case TestType::MergeIntVector:              return "IntVector";
-            case TestType::SortPoints:                  return "Points";
-            case TestType::SortIntVector:               return "IntVector";
-            // TODO: wiecej typow 5
-            case TestType::TransformMatrixToIntVector:  return "MatrixToIntVector";
-            // TODO: typy 6
-            case TestType::NthElementPoints:            return "Points";
-            case TestType::NthElementRandomString:      return "RandomString";
-            case TestType::RegexType:                   return "Regex";
-            // TODO: wiecej typow 9
-            case TestType::RemoveEraseIfSequence:       return "Sequence";
-            case TestType::GenerateFibonacci:           return "Fibonacci";
-            case TestType::GenerateRandomString:        return "RandomString";
-            case TestType::GenerateMatrix:              return "Matrix";
-            default:                                    return "!!! Nieznany typ testu !!!";
-        }
+        std::ostringstream os;
+        os << testType << ++testIdMap[testType] << ".txt";
+        return os.str();
     }
 };
 

--- a/tests/Wrapper/DynamicFeaturesTests.cpp
+++ b/tests/Wrapper/DynamicFeaturesTests.cpp
@@ -5,7 +5,7 @@ namespace tests::Wrapper
 
 TEST_F(DynamicFeatureTestFixture, DynamicIntVectorTest) 
 {
-    VerifyEverythingWorks<IntVector, false>(IntVector({ 11, 1, 2025, 15, 26 }));
+    VerifyMoveCopyWorks<IntVector, false>(IntVector({ 11, 1, 2025, 15, 26 }));
 }
 
 TEST_F(DynamicFeatureTestFixture, DynamicMatrixTest) 
@@ -13,17 +13,33 @@ TEST_F(DynamicFeatureTestFixture, DynamicMatrixTest)
     static const std::vector<int> inVec1{ 11, 1 };
     static const std::vector<int> inVec2{ 20, 25 };
     static const std::vector<std::vector<int>> outVec{ inVec1, inVec2 };
-    VerifyEverythingWorks<Matrix<int>, false>(Matrix<int>(outVec));
+    VerifyMoveCopyWorks<Matrix<int>, false>(Matrix<int>(outVec));
 }
 
 TEST_F(DynamicFeatureTestFixture, DynamicPoint2DTest) 
 {
-    VerifyEverythingWorks<Point2D, true>(Point2D(15, 26));
+    VerifyMoveCopyWorks<Point2D, true>(Point2D(15, 26));
+
+    // posortowane rosnaco - liczy sie najpierw 1 wspolrzedna x, potem druga y jesli x1 = x2
+    const Point2D p1(1, 12);
+    const Point2D p2(5, 2);
+    const Point2D p3(5, 5);
+    const Point2D p4(6, 1);
+    const Point2D p5(10, 1);
+
+    const std::vector<Point2D> inVector = { p2, p4, p1, p5, p3 };
+    const std::vector<Point2D> result1 = { p1, p4, p2, p5, p3 };
+    const std::vector<Point2D> result3 = { p2, p1, p3, p5, p4 };
+    const std::vector<Point2D> result5 = { p4, p2, p3, p1, p5 };
+
+    VerifyNthFinderWorks<std::vector<Point2D>>(inVector, 0, result1);
+    VerifyNthFinderWorks<std::vector<Point2D>>(inVector, 2, result3);
+    VerifyNthFinderWorks<std::vector<Point2D>>(inVector, 4, result5);
 }
 
 TEST_F(DynamicFeatureTestFixture, DynamicRandomStringTest) 
 {
-    VerifyEverythingWorks<RandomString, true>(RandomString(4));
+    VerifyMoveCopyWorks<RandomString, true>(RandomString(4));
 }
 
 } // namespace tests::Wrapper


### PR DESCRIPTION
1. Testy wykonują się w 160 sekund zamiast 550 dzięki przekazywaniu do GTEST.Values callbacka inicjalizującego dane testowe zamiast tych danych, co powodowało duże kopiowania.

2. Usunięcie konstruktorów/operatorów kopiujących z klas bazowych aby upewnić się, że nie wywołujemy ich zamiast przenoszenia.

3. Dodanie testów poprawności dla nth_element (żeby się upewnić, że wyliczane wartości są poprawne a nie tylko "tak samo błędne" w przypadku obliczeń na złych danych wejściowych).

4. Drobne poprawki kosmetyczne np. w wypisywaniu enuma TestType czy nazwy klasy w testach.