### PR TITLE
[Poprawka] Naprawienie niektórych testów, przeniesienie TEST_P do plików .cpp

### DIFF
--- a/src/Algorithms/Base.hpp
+++ b/src/Algorithms/Base.hpp
@@ -27,12 +27,12 @@ public:
 
     Results<ResultType> callEach() const
     {
-        const ResultType& stlResult = executeSTL();
+        ResultType stlResult = executeSTL();
         resetData();
-        const ResultType& boostResult = executeBoost();
+        ResultType boostResult = executeBoost();
         resetData();
-        const ResultType& simpleResult = executeSimple();
-        return Results(stlResult, boostResult, simpleResult);
+        ResultType simpleResult = executeSimple();
+        return Results(std::move(stlResult), std::move(boostResult), std::move(simpleResult));
     }
 
 protected:

--- a/tests/10Generate/Matrix3/MatrixTests.cpp
+++ b/tests/10Generate/Matrix3/MatrixTests.cpp
@@ -4,6 +4,16 @@
 namespace tests::Generate
 {
 
+TEST_P(MatrixGenerateIntFixture, intTest)
+{
+    VerifyTest(GetParam());
+}
+
+TEST_P(MatrixGenerateDoubleFixture, doubleTest)
+{
+    VerifyTest(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     GeneratePrefix, 
     MatrixGenerateIntFixture,

--- a/tests/10Generate/Matrix3/MatrixTests.hpp
+++ b/tests/10Generate/Matrix3/MatrixTests.hpp
@@ -37,14 +37,4 @@ class MatrixGenerateIntFixture : public GenerateTestFixture<CopyableMatrix<int>>
 class MatrixGenerateDoubleFixture : public GenerateTestFixture<CopyableMatrix<double>>
 { };
 
-TEST_P(MatrixGenerateIntFixture, intTest)
-{
-    VerifyTest(GetParam());
-}
-
-TEST_P(MatrixGenerateDoubleFixture, doubleTest)
-{
-    VerifyTest(GetParam());
-}
-
 } // namespace tests::Generate

--- a/tests/10Generate/RandomString2/RandomStringTests.cpp
+++ b/tests/10Generate/RandomString2/RandomStringTests.cpp
@@ -3,6 +3,11 @@
 namespace tests::Generate
 {
 
+TEST_P(RandomStringGenerateFixture, RandomStringGenerateTest) 
+{
+    VerifyTestCustomForRandomStringGenerator(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     GeneratePrefix,
     RandomStringGenerateFixture,

--- a/tests/10Generate/RandomString2/RandomStringTests.hpp
+++ b/tests/10Generate/RandomString2/RandomStringTests.hpp
@@ -51,9 +51,4 @@ private:
     }
 };
 
-TEST_P(RandomStringGenerateFixture, RandomStringGenerateTest) 
-{
-    VerifyTestCustomForRandomStringGenerator(GetParam());
-}
-
 } // namespace tests::Generate

--- a/tests/1MinMax/BasicSet3/UIntTests.cpp
+++ b/tests/1MinMax/BasicSet3/UIntTests.cpp
@@ -16,6 +16,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(BasicSetMinMaxFixture, BasicSetMinMaxTest)
+{
+    VerifyTestCustomFor1(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     MinMaxPrefix,
     BasicSetMinMaxFixture,

--- a/tests/1MinMax/BasicSet3/UIntTests.hpp
+++ b/tests/1MinMax/BasicSet3/UIntTests.hpp
@@ -38,9 +38,4 @@ public:
     }
 };
 
-TEST_P(BasicSetMinMaxFixture, BasicSetMinMaxTest)
-{
-    VerifyTestCustomFor1(GetParam());
-}
-
 } // namespace tests::MinMax

--- a/tests/1MinMax/BasicVector1/UIntTests.cpp
+++ b/tests/1MinMax/BasicVector1/UIntTests.cpp
@@ -16,6 +16,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(BasicVectorMinMaxFixture, BasicVectorMinMaxTest)
+{
+    VerifyTestCustomFor1(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     MinMaxPrefix,
     BasicVectorMinMaxFixture,

--- a/tests/1MinMax/BasicVector1/UIntTests.hpp
+++ b/tests/1MinMax/BasicVector1/UIntTests.hpp
@@ -38,9 +38,4 @@ public:
     }
 };
 
-TEST_P(BasicVectorMinMaxFixture, BasicVectorMinMaxTest)
-{
-    VerifyTestCustomFor1(GetParam());
-}
-
 } // namespace tests::MinMax

--- a/tests/1MinMax/VectorOfVectors2/IntVectorTests.cpp
+++ b/tests/1MinMax/VectorOfVectors2/IntVectorTests.cpp
@@ -16,6 +16,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(VectorOfVectorsMinMaxFixture, VectorOfVectorsMinMaxTest)
+{
+    VerifyTestCustomFor1(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     MinMaxPrefix,
     VectorOfVectorsMinMaxFixture,

--- a/tests/1MinMax/VectorOfVectors2/IntVectorTests.hpp
+++ b/tests/1MinMax/VectorOfVectors2/IntVectorTests.hpp
@@ -60,9 +60,4 @@ public:
     }
 };
 
-TEST_P(VectorOfVectorsMinMaxFixture, VectorOfVectorsMinMaxTest)
-{
-    VerifyTestCustomFor1(GetParam());
-}
-
 } // namespace tests::MinMax

--- a/tests/1MinMax/VectorSet4/IntVectorTests.cpp
+++ b/tests/1MinMax/VectorSet4/IntVectorTests.cpp
@@ -16,6 +16,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(VectorSetMinMaxFixture, VectorSetMinMaxTest)
+{
+    VerifyTestCustomFor1(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     MinMaxPrefix,
     VectorSetMinMaxFixture,

--- a/tests/1MinMax/VectorSet4/IntVectorTests.hpp
+++ b/tests/1MinMax/VectorSet4/IntVectorTests.hpp
@@ -60,9 +60,4 @@ public:
     }
 };
 
-TEST_P(VectorSetMinMaxFixture, VectorSetMinMaxTest)
-{
-    VerifyTestCustomFor1(GetParam());
-}
-
 } // namespace tests::MinMax

--- a/tests/2Accumulate/Matrix3/MatrixTests.cpp
+++ b/tests/2Accumulate/Matrix3/MatrixTests.cpp
@@ -45,6 +45,16 @@ static std::vector<std::shared_ptr<Base<double>>> getDoubleTests()
     return tests;
 }
 
+TEST_P(MatrixAccumulateIntFixture, intTest)
+{
+    VerifyTestCustomFor2(GetParam());
+}
+
+TEST_P(MatrixAccumulateDoubleFixture, doubleTest)
+{
+    VerifyTestCustomFor2(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AccumulatePrefix,
     MatrixAccumulateIntFixture,

--- a/tests/2Accumulate/Matrix3/MatrixTests.hpp
+++ b/tests/2Accumulate/Matrix3/MatrixTests.hpp
@@ -44,14 +44,4 @@ class MatrixAccumulateIntFixture : public AccumulateTestFixture<CopyableMatrix<i
 class MatrixAccumulateDoubleFixture : public AccumulateTestFixture<CopyableMatrix<double>>
 { };
 
-TEST_P(MatrixAccumulateIntFixture, intTest)
-{
-    VerifyTestCustomFor2(GetParam());
-}
-
-TEST_P(MatrixAccumulateDoubleFixture, doubleTest)
-{
-    VerifyTestCustomFor2(GetParam());
-}
-
 } // namespace tests::Accumulate

--- a/tests/2Accumulate/Points2/PointsTests.cpp
+++ b/tests/2Accumulate/Points2/PointsTests.cpp
@@ -30,6 +30,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(PointsAccumulateFixture, PointsAccumulateTest)
+{
+    VerifyTestCustomFor2(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AccumulatePrefix,
     PointsAccumulateFixture,

--- a/tests/2Accumulate/Points2/PointsTests.hpp
+++ b/tests/2Accumulate/Points2/PointsTests.hpp
@@ -41,9 +41,4 @@ public:
     }
 };
 
-TEST_P(PointsAccumulateFixture, PointsAccumulateTest)
-{
-    VerifyTestCustomFor2(GetParam());
-}
-
 } // namespace tests::Accumulate

--- a/tests/2Accumulate/UInt1/UIntTests.cpp
+++ b/tests/2Accumulate/UInt1/UIntTests.cpp
@@ -30,6 +30,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(UIntAccumulateFixture, UIntAccumulateTest)
+{
+    VerifyTestCustomFor2(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AccumulatePrefix,
     UIntAccumulateFixture,

--- a/tests/2Accumulate/UInt1/UIntTests.hpp
+++ b/tests/2Accumulate/UInt1/UIntTests.hpp
@@ -38,9 +38,4 @@ public:
     }
 };
 
-TEST_P(UIntAccumulateFixture, UIntAccumulateTest)
-{
-    VerifyTestCustomFor2(GetParam());
-}
-
 } // namespace tests::Accumulate

--- a/tests/3Merge/Points1/PointsTests.cpp
+++ b/tests/3Merge/Points1/PointsTests.cpp
@@ -17,6 +17,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(PointsMergeFixture, PointsMergeTest)
+{
+    VerifyTest(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     MergePrefix,
     PointsMergeFixture,

--- a/tests/3Merge/Points1/PointsTests.hpp
+++ b/tests/3Merge/Points1/PointsTests.hpp
@@ -39,9 +39,4 @@ public:
     }
 };
 
-TEST_P(PointsMergeFixture, PointsMergeTest)
-{
-    VerifyTest(GetParam());
-}
-
 } // namespace tests::Merge

--- a/tests/3Merge/Vector3/IntVectorTests.cpp
+++ b/tests/3Merge/Vector3/IntVectorTests.cpp
@@ -17,6 +17,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(IntVectorMergeFixture, IntVectorTest)
+{
+    VerifyTest(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     MergePrefix,
     IntVectorMergeFixture,

--- a/tests/3Merge/Vector3/IntVectorTests.hpp
+++ b/tests/3Merge/Vector3/IntVectorTests.hpp
@@ -51,9 +51,4 @@ public:
     }
 };
 
-TEST_P(IntVectorMergeFixture, IntVectorTest)
-{
-    VerifyTest(GetParam());
-}
-
 } // namespace tests::Merge

--- a/tests/4Sort/Points1/PointsTests.cpp
+++ b/tests/4Sort/Points1/PointsTests.cpp
@@ -19,6 +19,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(PointsSortFixture, pointsSortTest)
+{
+    VerifyTest(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     SortPrefix,
     PointsSortFixture,

--- a/tests/4Sort/Points1/PointsTests.hpp
+++ b/tests/4Sort/Points1/PointsTests.hpp
@@ -63,9 +63,4 @@ public:
     }
 };
 
-TEST_P(PointsSortFixture, pointsSortTest)
-{
-    VerifyTest(GetParam());
-}
-
 } // namespace tests::Sort

--- a/tests/4Sort/Vector3/IntVectorTests.cpp
+++ b/tests/4Sort/Vector3/IntVectorTests.cpp
@@ -19,6 +19,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(IntVectorSortFixture, IntVectorSortTest)
+{
+    VerifyTest(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     SortPrefix,
     IntVectorSortFixture,

--- a/tests/4Sort/Vector3/IntVectorTests.hpp
+++ b/tests/4Sort/Vector3/IntVectorTests.hpp
@@ -71,9 +71,4 @@ public:
     }
 };
 
-TEST_P(IntVectorSortFixture, IntVectorSortTest)
-{
-    VerifyTest(GetParam());
-}
-
 } // namespace tests::Sort

--- a/tests/7NthElement/Points1/PointsTests.cpp
+++ b/tests/7NthElement/Points1/PointsTests.cpp
@@ -28,6 +28,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(PointsNthElementFixture, PointsNthElementTest)
+{
+    VerifyTestCustomFor7(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     NthElementPrefix,
     PointsNthElementFixture,

--- a/tests/7NthElement/Points1/PointsTests.hpp
+++ b/tests/7NthElement/Points1/PointsTests.hpp
@@ -39,9 +39,4 @@ public:
     }
 };
 
-TEST_P(PointsNthElementFixture, PointsNthElementTest)
-{
-    VerifyTestCustomFor7(GetParam());
-}
-
 } // namespace tests::NthElement

--- a/tests/7NthElement/RandomString2/RandomStringTests.cpp
+++ b/tests/7NthElement/RandomString2/RandomStringTests.cpp
@@ -25,6 +25,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(RandomStringNthElementFixture, RandomStringNthElementTest)
+{
+    VerifyTestCustomFor7(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     NthElementPrefix,
     RandomStringNthElementFixture,

--- a/tests/7NthElement/RandomString2/RandomStringTests.hpp
+++ b/tests/7NthElement/RandomString2/RandomStringTests.hpp
@@ -29,9 +29,4 @@ class RandomStringNthElementFixture : public NthElementTestFixture<Container>
 {
 };
 
-TEST_P(RandomStringNthElementFixture, RandomStringNthElementTest)
-{
-    VerifyTestCustomFor7(GetParam());
-}
-
 } // namespace tests::NthElement

--- a/tests/8Regex/RegexTests.cpp
+++ b/tests/8Regex/RegexTests.cpp
@@ -13,6 +13,11 @@ static std::vector<std::shared_ptr<Base>> getTests()
     return tests;
 }
 
+TEST_P(RegexTestFixture, RegexTest)
+{
+    VerifyTest(GetParam());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     RegexPrefix,
     RegexTestFixture,

--- a/tests/8Regex/RegexTests.hpp
+++ b/tests/8Regex/RegexTests.hpp
@@ -59,9 +59,4 @@ class RegexTestFixture : public BaseTestFixture<std::vector<std::string>>
 {
 };
 
-TEST_P(RegexTestFixture, RegexTest)
-{
-    VerifyTest(GetParam());
-}
-
 } // namespace tests::Regex

--- a/tests/Static/StaticFixture.hpp
+++ b/tests/Static/StaticFixture.hpp
@@ -81,7 +81,7 @@ protected:
     void VerifyAccumulateWorks(std::vector<DataType>&& elements,
         const AccResults<DataType>& expectedResult) const
     {
-        const Accumulator<DataType> accumulator(std::move(elements), AccType::SumOnly);
+        const Accumulator<DataType> accumulator(std::move(elements), AccType::DoItAll);
         auto [stlResult, boostResult, simpleResult] = accumulator.callEach();
 
         EXPECT_EQ(stlResult.sum, expectedResult.sum) << "Suma STL jest niepoprawna";
@@ -121,9 +121,9 @@ protected:
 
     // 5. Transform
     template <typename InDataType, typename ReturnDataType>
-    void VerifyTransformWorks(InDataType&& elements,
+    void VerifyTransformWorks(std::vector<InDataType>&& elements,
         ReturnDataType (*const converter)(const InDataType&),
-        const ReturnDataType& expectedResult) const
+        const std::vector<ReturnDataType>& expectedResult) const
     {
         const Transformer<InDataType, ReturnDataType> transformer(std::move(elements), converter);
         VerifyAlgorithmWorks(transformer, expectedResult);

--- a/tests/Static/StaticTests.cpp
+++ b/tests/Static/StaticTests.cpp
@@ -102,22 +102,22 @@ TEST_F(StaticTestFixture, MinMaxTest)
     VerifyMinMaxWorks(IvSet(), minMaxIvResult);
 }
 
-// 2. Accumulate TODO: Naprawic niedzialajace testy
+// 2. Accumulate TODO: Naprawic niedzialajace testy Matrix
 TEST_F(StaticTestFixture, AccumulateTest)
 {
-    // AccResults<int> accumulateUIntResult;
-    // accumulateUIntResult.minimum = 1;
-    // accumulateUIntResult.maximum = 7;
-    // accumulateUIntResult.mean = 4;
-    // accumulateUIntResult.sum = 28;
-    // VerifyAccumulateWorks({ 2, 1, 3, 7, 5, 6, 4 }, accumulateUIntResult);
+    AccResults<int> accumulateUIntResult;
+    accumulateUIntResult.minimum = 1;
+    accumulateUIntResult.maximum = 7;
+    accumulateUIntResult.mean = 4;
+    accumulateUIntResult.sum = 28;
+    VerifyAccumulateWorks({ 2, 1, 3, 7, 5, 6, 4 }, accumulateUIntResult);
 
-    // AccResults<CopyablePair<int>> accumulateIntResult;
-    // accumulateIntResult.minimum = p1();
-    // accumulateIntResult.maximum = p5();
-    // accumulateIntResult.mean = p4();
-    // accumulateIntResult.sum = CopyablePair<int>(30, 25);
-    // VerifyAccumulateWorks(PointVector(), accumulateIntResult);
+    AccResults<CopyablePair<int>> accumulatePointResult;
+    accumulatePointResult.minimum = p1();
+    accumulatePointResult.maximum = p5();
+    accumulatePointResult.mean = p4();
+    accumulatePointResult.sum = CopyablePair<int>(30, 25);
+    VerifyAccumulateWorks(PointVector(), accumulatePointResult);
 
     // auto values1 = []() -> std::vector<std::vector<int>> { return {{10, 2}, {16, 33}}; };
     // auto values2 = []() -> std::vector<std::vector<int>> { return {{30, 6}, {48, 99}}; };
@@ -150,21 +150,34 @@ TEST_F(StaticTestFixture, SortTest)
     VerifySortWorks(IvVector(), sortedIvVector());
 }
 
-// 5. Transform TODO: Naprawic niedzialajace testy
+// 5. Transform
 TEST_F(StaticTestFixture, TransformTest)
 {
-    // VerifyTransformWorks<NonCopyableMatrix<int>, std::vector<NonCopyableIntVector>>(
-    //     { NCM1() },
-    //     &Transform::MatrixToIntVectorTransformArgs::transformer,
-    //     { matrixIvVector() });
+    NonCopyableMatrix<int> ncm = NCM1();
+    std::vector<NonCopyableMatrix<int>> inVec;
+    inVec.emplace_back(std::move(ncm));
 
-    // std::vector<unsigned int> vectorWithDuplicates = { 2, 1, 2, 3, 1, 7, 7, 2 };
-    // const std::map<unsigned int, unsigned int> mapWithoutDuplicates = { { 1, 2 }, { 2, 3 }, { 3, 1 }, { 7, 2 } };
+    std::vector<NonCopyableIntVector> mIntVec = matrixIvVector();
+    std::vector<std::vector<NonCopyableIntVector>> outVec;
+    outVec.emplace_back(std::move(mIntVec));
 
-    // VerifyTransformWorks(
-    //     std::move(vectorWithDuplicates),
-    //     &Transform::VectorToMapTransformArgs::transformer,
-    //     mapWithoutDuplicates);
+    VerifyTransformWorks<NonCopyableMatrix<int>, std::vector<NonCopyableIntVector>>(
+        std::move(inVec),
+        &Transform::MatrixToIntVectorTransformArgs::transformer,
+        outVec);
+
+    std::vector<unsigned int> vectorWithDuplicates = { 2, 1, 2, 3, 1, 7, 7, 2 };
+    std::vector<std::vector<unsigned int>> inVec2;
+    inVec2.emplace_back(std::move(vectorWithDuplicates));
+
+    std::map<unsigned int, unsigned int> mapWithoutDuplicates = { { 1, 2 }, { 2, 3 }, { 3, 1 }, { 7, 2 } };
+    std::vector<std::map<unsigned int, unsigned int>> outVec2;
+    outVec2.emplace_back(std::move(mapWithoutDuplicates));
+
+    VerifyTransformWorks<std::vector<unsigned int>, std::map<unsigned int, unsigned int>>(
+        std::move(inVec2),
+        &Transform::VectorToMapTransformArgs::transformer,
+        outVec2);
 }
 
 // TODO: 6. ???


### PR DESCRIPTION
TEST_P powinny być w tym samym pliku co INSTANTIATE_TEST_SUITE_P inaczej przy includowaniu hpp w 2 różnych miejscach kompilator będzie wymagał 2 implementacji TEST_P co mija się z celem.